### PR TITLE
Fix rename endpoint

### DIFF
--- a/migrations/20241009032342_update_old_names_primary_key.sql
+++ b/migrations/20241009032342_update_old_names_primary_key.sql
@@ -1,0 +1,9 @@
+-- Add migration script here
+-- 1. Drop the primary key on id and remove the id column
+ALTER TABLE old_names
+DROP CONSTRAINT old_names_pkey, -- Drop the current primary key on id
+DROP COLUMN id;
+
+-- Remove the id column
+-- 2. Add a new primary key on old_username
+ALTER TABLE old_names ADD CONSTRAINT old_names_pkey PRIMARY KEY (old_username);

--- a/src/types/database.rs
+++ b/src/types/database.rs
@@ -46,7 +46,6 @@ impl Name {
 #[allow(dead_code)]
 #[derive(Debug, FromRow, PgInsert)]
 pub struct MovedRecord {
-	pub id: f64,
 	pub old_username: String,
 	pub new_username: String,
 }


### PR DESCRIPTION
Previously we were trying to insert without specifying an id or incrementing it. I am removing the id column since we dont use it for anything and making the old_name the primary key