### PR TITLE
Improve Error Logging

### DIFF
--- a/src/routes/api/v1/register_username.rs
+++ b/src/routes/api/v1/register_username.rs
@@ -29,13 +29,22 @@ pub async fn register_username(
 	{
 		Ok(()) => {},
 		Err(verify::Error::Verification(e)) => {
-			tracing::error!("Register Verification Error: {:?}", payload);
+			tracing::error!(
+				"Register Verification Error: {}, Payload: {:?}",
+				e.detail,
+				payload
+			);
 			return Err(ErrorResponse::validation_error(e.detail));
 		},
-		Err(_) => {
+		Err(e) => {
+			tracing::error!(
+				"Register Server Error: {}, Payload: {:?}",
+				e.to_string(),
+				payload
+			);
 			return Err(ErrorResponse::server_error(
 				"Failed to verify World ID proof".to_string(),
-			))
+			));
 		},
 	};
 

--- a/src/routes/api/v1/rename.rs
+++ b/src/routes/api/v1/rename.rs
@@ -46,13 +46,22 @@ pub async fn rename(
 	{
 		Ok(()) => {},
 		Err(verify::Error::Verification(e)) => {
-			tracing::error!("Rename Verification Error: {:?}", payload);
+			tracing::error!(
+				"Rename Verification Error: {}, Payload: {:?}",
+				e.detail,
+				payload
+			);
 			return Err(ErrorResponse::validation_error(e.detail));
 		},
-		Err(_) => {
+		Err(e) => {
+			tracing::error!(
+				"Rename Server Error: {}, Payload: {:?}",
+				e.to_string(),
+				payload
+			);
 			return Err(ErrorResponse::server_error(
 				"Failed to verify World ID proof".to_string(),
-			))
+			));
 		},
 	};
 

--- a/src/routes/api/v1/update_record.rs
+++ b/src/routes/api/v1/update_record.rs
@@ -48,13 +48,22 @@ pub async fn update_record(
 	{
 		Ok(()) => {},
 		Err(verify::Error::Verification(e)) => {
-			tracing::error!("Update Record Verification Error: {:?}", payload);
+			tracing::error!(
+				"Update Record Verification Error: {}, Payload: {:?}",
+				e.detail,
+				payload
+			);
 			return Err(ErrorResponse::validation_error(e.detail));
 		},
-		Err(_) => {
+		Err(e) => {
+			tracing::error!(
+				"Update Record Server Error: {}, Payload: {:?}",
+				e.to_string(),
+				payload
+			);
 			return Err(ErrorResponse::server_error(
 				"Failed to verify World ID proof".to_string(),
-			))
+			));
 		},
 	};
 


### PR DESCRIPTION
Sometimes we get errors that are not invalid proof but are being reported as invalid proof. The verification error should catch the invalid proof errors.

In addition verification error is broad we should print what the exact error was in that enum