### PR TITLE
Improve search speed

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
-    "solidity.compileUsingRemoteVersion": "v0.8.26+commit.8a97fa7a",
-    "cSpell.words": [
-        "sqlx"
-    ]
+  "solidity.compileUsingRemoteVersion": "v0.8.26+commit.8a97fa7a",
+  "cSpell.words": ["sqlx"],
+  "editor.formatOnSave": true,
+  "rust-analyzer.check.command": "clippy"
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+components = ["rustfmt", "clippy"]   # Additional tools to install

--- a/src/routes/api/v1/search.rs
+++ b/src/routes/api/v1/search.rs
@@ -22,21 +22,22 @@ pub async fn search(
 	let names = sqlx::query_as!(
 		Name,
 		"SELECT * FROM names
-			WHERE username % $1
-			ORDER BY username <-> $1
-			LIMIT 10;",
+		WHERE username % $1 
+		AND similarity(username, $1) > 0.4
+		ORDER BY username <-> $1
+		LIMIT 10;",
 		lowercase_username
 	)
 	.fetch_all(&db.read_only)
 	.await?;
 
-	return Ok(Json(
+	Ok(Json(
 		names
 			.into_iter()
 			.map(UsernameRecord::from)
 			.collect::<Vec<UsernameRecord>>(),
 	)
-	.into_response());
+	.into_response())
 }
 
 pub fn docs(op: aide::transform::TransformOperation) -> aide::transform::TransformOperation {


### PR DESCRIPTION
Improve search speed by adding a similarity score filter. This lets PG filter out poor matches earlier on so it doesn't need to search for everything