### PR TITLE
Use Union instead of OR

### DIFF
--- a/src/routes/api/v1/query_single.rs
+++ b/src/routes/api/v1/query_single.rs
@@ -19,7 +19,7 @@ pub async fn query_single(
 ) -> Result<Response, ErrorResponse> {
 	if let Some(name) = sqlx::query_as!(
 		Name,
-		"SELECT * FROM names WHERE username = $1 OR address = $1",
+		"SELECT * FROM names WHERE username = $1 UNION ALL SELECT * FROM names WHERE address = $1 AND username <> $1",
 		validate_address(&name_or_address)
 	)
 	.fetch_optional(&db.read_only)


### PR DESCRIPTION
See these [logs](https://app.datadoghq.com/logs?query=env%3Aproduction%20service%3Awld-usernames&agg_m=count&agg_m_source=base&agg_t=count&cols=host%2Cservice&event=AwAAAZQ8PnoVMiP6-AAAABhBWlE4UG51V0FBQzRDaFRhRHZrOVVBQUEAAAAkMDE5NDNjNDAtNzk1OS00Yzk1LThjZWEtNGNlMzc2NTkzNzI1AAnfgA&fromUser=true&messageDisplay=inline&refresh_mode=paused&storage=hot&stream_sort=desc&viz=stream&from_ts=1736177400000&to_ts=1736177520000&live=false)

This query consistently performs slowly. We should use union here since there's two separate columns that need to be searched. [see](https://stackoverflow.com/questions/13750475/sql-performance-union-vs-or)
```
SELECT
  *
FROM
  names
WHERE
  username = $1
  OR address = $1
```

UNION All additionally lets it skip a duplicate check since we know there cannot be duplicate addresses or usernames