### PR TITLE
allow to match dot+0-4 numbers at the end

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,7 @@ pub static USERNAME_REGEX: LazyLock<Regex> =
 pub static DEVICE_USERNAME_REGEX: LazyLock<Regex> =
 	LazyLock::new(|| Regex::new(r"^[a-z]\w{2,13}[a-z0-9]\.\d{4}$").unwrap());
 pub static USERNAME_SEARCH_REGEX: LazyLock<Regex> =
-	LazyLock::new(|| Regex::new(r"^[a-z]\w{0,13}[a-z0-9]$").unwrap());
+	LazyLock::new(|| Regex::new(r"^[a-z]\w{0,13}([a-z0-9](\.\d{4})?)$").unwrap());
 
 #[derive(Debug)]
 pub struct Config {


### PR DESCRIPTION
this will allow users to search for unverified usernames more easily