### PR TITLE
Improve DB config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -81,15 +81,17 @@ impl Config {
 		);
 
 		let db_client = PgPoolOptions::new()
-			.max_connections(100)
-			.acquire_timeout(Duration::from_secs(3))
+			.max_connections(32)
+			.acquire_timeout(Duration::from_secs(4))
 			.connect(
 				&env::var("DATABASE_URL").context("DATABASE_URL environment variable not set")?,
 			)
 			.await?;
 
 		let db_read_client = PgPoolOptions::new()
-			.acquire_timeout(Duration::from_secs(3))
+			.min_connections(2)
+			.max_connections(32)
+			.acquire_timeout(Duration::from_secs(4))
 			.connect(
 				&env::var("DATABASE_READ_URL")
 					.context("DATABASE_READ_URL environment variable not set")?,

--- a/src/config.rs
+++ b/src/config.rs
@@ -81,7 +81,7 @@ impl Config {
 		);
 
 		let db_client = PgPoolOptions::new()
-			.max_connections(32)
+			.max_connections(50)
 			.acquire_timeout(Duration::from_secs(4))
 			.connect(
 				&env::var("DATABASE_URL").context("DATABASE_URL environment variable not set")?,


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
Timeouts with connection and DB. Outside of optimizing queries lets increase the min read connections from 10 -> 32 and allow 2 to persist. My thought is that this will allow better scaling with a higher max and reduce upstart time to acquire a connection with the serverless read instance. Also write seemed to high so reducing

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
