### PR TITLE
DataDog Tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5617,7 +5617,9 @@ dependencies = [
  "bitflags 2.8.0",
  "bytes",
  "http 1.2.0",
+ "http-body 1.0.1",
  "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,7 +373,7 @@ dependencies = [
  "lru",
  "parking_lot",
  "pin-project 1.1.8",
- "reqwest",
+ "reqwest 0.12.12",
  "schnellru",
  "serde",
  "serde_json",
@@ -417,7 +417,7 @@ dependencies = [
  "alloy-transport-http",
  "futures",
  "pin-project 1.1.8",
- "reqwest",
+ "reqwest 0.12.12",
  "serde",
  "serde_json",
  "tokio",
@@ -659,7 +659,7 @@ source = "git+https://github.com/alloy-rs/alloy.git#70df381dd5ae09133137bd8c51b5
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
- "reqwest",
+ "reqwest 0.12.12",
  "serde_json",
  "tower 0.5.2",
  "tracing",
@@ -1316,7 +1316,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower 0.5.2",
  "tower-layer",
@@ -1339,7 +1339,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1363,6 +1363,24 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "tracing",
+]
+
+[[package]]
+name = "axum-tracing-opentelemetry"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdad298231394729042d1f155b93f9fdf0b5ee1aea0b62404c4d7341f7d8fe08"
+dependencies = [
+ "axum",
+ "futures-core",
+ "futures-util",
+ "http 1.2.0",
+ "opentelemetry",
+ "pin-project-lite",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
 ]
 
 [[package]]
@@ -1759,6 +1777,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06ba6d68e24814cb8de6bb986db8222d3a027d15872cabc0d18817bc3c0e4471"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1848,6 +1875,35 @@ dependencies = [
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "datadog-tracing"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c209992199ce38d760f9e65541c70560ce7424859c495fff9c4bcd7c6921d69c"
+dependencies = [
+ "axum",
+ "axum-tracing-opentelemetry",
+ "chrono",
+ "futures-util",
+ "http 1.2.0",
+ "opentelemetry",
+ "opentelemetry-datadog",
+ "opentelemetry-http",
+ "opentelemetry_sdk",
+ "pin-project-lite",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower 0.4.13",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-opentelemetry-instrumentation-sdk",
+ "tracing-serde 0.1.3",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2302,7 +2358,7 @@ dependencies = [
  "once_cell",
  "prost",
  "prost-types",
- "reqwest",
+ "reqwest 0.12.12",
  "secret-vault-value",
  "serde",
  "serde_json",
@@ -2849,7 +2905,7 @@ checksum = "1428f8183b5df215f8b620cc2529fa284e93a97391b74461c6b6b5ebc9d4f2f4"
 dependencies = [
  "alloy-sol-types",
  "base64 0.21.7",
- "reqwest",
+ "reqwest 0.12.12",
  "ring",
  "ruint",
  "serde",
@@ -2943,6 +2999,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -3499,6 +3564,96 @@ dependencies = [
 ]
 
 [[package]]
+name = "opentelemetry"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e32339a5dc40459130b3bd269e9892439f55b33e772d2a9d402a789baaf4e8a"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "indexmap 2.7.0",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "urlencoding",
+]
+
+[[package]]
+name = "opentelemetry-datadog"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e09667367cb509f10d7cf5960a83f9c4d96e93715f750b164b4b98d46c3cbf4"
+dependencies = [
+ "futures-core",
+ "http 0.2.12",
+ "indexmap 2.7.0",
+ "itertools 0.11.0",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "reqwest 0.11.27",
+ "rmp",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f51189ce8be654f9b5f7e70e49967ed894e84a06fc35c6c042e64ac1fc5399e"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http 0.2.12",
+ "opentelemetry",
+ "reqwest 0.11.27",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5774f1ef1f982ef2a447f6ee04ec383981a3ab99c8e77a1a7b30182e65bbc84"
+dependencies = [
+ "opentelemetry",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f16aec8a98a457a52664d69e0091bac3a0abd18ead9b641cb00202ba4e0efe4"
+dependencies = [
+ "async-trait",
+ "crossbeam-channel",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float",
+ "percent-encoding",
+ "rand",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3855,7 +4010,7 @@ dependencies = [
  "thiserror 2.0.11",
  "tinyvec",
  "tracing",
- "web-time",
+ "web-time 1.1.0",
 ]
 
 [[package]]
@@ -4017,6 +4172,42 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
@@ -4052,8 +4243,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
- "system-configuration",
+ "sync_wrapper 1.0.2",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.1",
@@ -4101,6 +4292,17 @@ checksum = "bb919243f34364b6bd2fc10ef797edbfa75f33c252e7998527479c6d6b47e1ec"
 dependencies = [
  "bytes",
  "rustc-hex",
+]
+
+[[package]]
+name = "rmp"
+version = "0.8.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "228ed7c16fa39782c3b3468e974aec2795e9089153cd08ee2e9aefb3613334c4"
+dependencies = [
+ "byteorder",
+ "num-traits",
+ "paste",
 ]
 
 [[package]]
@@ -4309,7 +4511,7 @@ version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
 dependencies = [
- "web-time",
+ "web-time 1.1.0",
 ]
 
 [[package]]
@@ -5026,6 +5228,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -5046,13 +5254,34 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.8.0",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -5372,7 +5601,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -5430,6 +5659,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror 1.0.69",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5462,6 +5703,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-opentelemetry"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c67ac25c5407e7b961fafc6f7e9aa5958fd297aada2d20fa2ae1737357e55596"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time 0.2.4",
+]
+
+[[package]]
+name = "tracing-opentelemetry-instrumentation-sdk"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9920abb6a3ee3a2af7d30c9ff02900f8481935d36723c3da95cf807468218e8c"
+dependencies = [
+ "http 1.2.0",
+ "opentelemetry",
+ "tracing",
+ "tracing-opentelemetry",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
 name = "tracing-serde"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5489,7 +5770,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
+ "tracing-serde 0.2.0",
 ]
 
 [[package]]
@@ -5777,6 +6058,16 @@ dependencies = [
 
 [[package]]
 name = "web-time"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa30049b1c872b72c89866d458eae9f20380ab280ffd1b1e18df2d3e2d98cfe0"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
@@ -6035,6 +6326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "wld-usernames"
 version = "0.1.0"
 dependencies = [
@@ -6046,6 +6347,7 @@ dependencies = [
  "axum",
  "axum-jsonschema",
  "chrono",
+ "datadog-tracing",
  "dotenvy",
  "hex",
  "http 1.2.0",
@@ -6053,7 +6355,7 @@ dependencies = [
  "num-traits",
  "redis",
  "regex",
- "reqwest",
+ "reqwest 0.12.12",
  "ruint",
  "rustls 0.23.21",
  "schemars",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ dotenvy = "0.15.7"
 thiserror = "1.0.69"
 num-traits = "0.2.19"
 serde_json = "1.0.135"
+datadog-tracing = { version = "0.2.3", features = ["axum"] }
 url = { version = "2.5.4", features = ["serde"] }
 tokio = { version = "1.43.0", features = ["full"] }
 chrono = { version = "0.4.39", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ tokio = { version = "1.43.0", features = ["full"] }
 chrono = { version = "0.4.39", features = ["serde"] }
 reqwest = { version = "0.12.12", features = ["json"] }
 serde = { version = "1.0.217", features = ["derive"] }
-tower-http = { version = "0.6.2", features = ["cors"] }
+tower-http = { version = "0.6.2", features = ["cors", "timeout"] }
 axum-jsonschema = { version = "0.8.0", features = ["aide"] }
 schemars = { version = "0.8.21", features = ["chrono", "url"] }
 aide = { version = "0.13.4", features = ["axum", "macros", "scalar"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ mod utils;
 mod verify;
 
 #[tokio::main]
+#[tracing::instrument]
 async fn main() -> anyhow::Result<()> {
 	dotenvy::dotenv().ok();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,8 @@ mod verify;
 async fn main() -> anyhow::Result<()> {
 	dotenvy::dotenv().ok();
 
-	tracing_subscriber::fmt()
-		.json()
-		.with_target(false)
-		.flatten_event(true)
-		.init();
+	// Initialize Datadog tracing
+	let (_guard, _tracer_shutdown) = datadog_tracing::init()?;
 
 	tracing::info!("👩 Server started");
 

--- a/src/routes/api/v1/query_multiple.rs
+++ b/src/routes/api/v1/query_multiple.rs
@@ -6,6 +6,7 @@ use crate::{
 	types::{ErrorResponse, Name, QueryAddressesPayload, UsernameRecord},
 };
 
+#[tracing::instrument(skip_all)]
 pub async fn query_multiple(
 	Extension(db): Extension<Db>,
 	Json(payload): Json<QueryAddressesPayload>,

--- a/src/routes/api/v1/query_single.rs
+++ b/src/routes/api/v1/query_single.rs
@@ -9,12 +9,13 @@ use axum::{
 use axum_jsonschema::Json;
 use redis::{aio::ConnectionManager, AsyncCommands};
 
-use crate::utils::ONE_MINUTE_IN_SECONDS;
 use crate::{
 	config::Db,
 	types::{ErrorResponse, MovedRecord, Name, UsernameRecord},
+	utils::ONE_MINUTE_IN_SECONDS,
 };
 
+#[tracing::instrument(skip_all)]
 pub async fn query_single(
 	Extension(db): Extension<Db>,
 	Extension(mut redis): Extension<ConnectionManager>,

--- a/src/routes/api/v1/register_username.rs
+++ b/src/routes/api/v1/register_username.rs
@@ -10,6 +10,7 @@ use crate::{
 	verify,
 };
 
+#[tracing::instrument(skip_all)]
 #[allow(dependency_on_unit_never_type_fallback)]
 pub async fn register_username(
 	Extension(config): ConfigExt,

--- a/src/routes/api/v1/rename.rs
+++ b/src/routes/api/v1/rename.rs
@@ -11,6 +11,7 @@ use crate::{
 };
 use redis::{aio::ConnectionManager, AsyncCommands};
 
+#[tracing::instrument(skip_all)]
 #[allow(clippy::too_many_lines)] // TODO: refactor
 #[allow(dependency_on_unit_never_type_fallback)]
 pub async fn rename(

--- a/src/routes/api/v1/search.rs
+++ b/src/routes/api/v1/search.rs
@@ -1,7 +1,7 @@
-use crate::utils::ONE_MINUTE_IN_SECONDS;
 use crate::{
 	config::{Db, USERNAME_SEARCH_REGEX},
 	types::{ErrorResponse, NameSearch, UsernameRecord},
+	utils::ONE_MINUTE_IN_SECONDS,
 };
 use axum::{
 	extract::Path,
@@ -9,9 +9,9 @@ use axum::{
 	Extension,
 };
 use axum_jsonschema::Json;
-use redis::aio::ConnectionManager;
-use redis::AsyncCommands;
+use redis::{aio::ConnectionManager, AsyncCommands};
 
+#[tracing::instrument(skip_all)]
 pub async fn search(
 	Extension(db): Extension<Db>,
 	Extension(mut redis): Extension<ConnectionManager>,


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
Enable DataDog tracing with an alternative library to get rid of the memory leak issue.

The approach is the same as we have in the [invites](https://app.datadoghq.com/apm/traces?query=service%3Ainvites&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=false&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanType=all&storage=hot&view=spans&start=1737386839849&end=1737387739849&paused=false) service with the [datadog-tracing](https://github.com/worldcoin/app-backend-invites/blob/fbe56f9719e540b17f93ab116fe47cb73ce82a34/src/invites/invite-stats/invite-stats.lambda/Cargo.toml#L19) library

This code is deployed on `staging` and there are traces both custom and standard:
![image](https://github.com/user-attachments/assets/ade535c9-5279-4655-82d3-493e90880210)
The traces have sub-spans included:
![image](https://github.com/user-attachments/assets/2b32eb63-ecbe-414e-a8fb-8be7f0f6fe2f)


<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
