### PR TITLE
fix: no double logging, better debug info, adjusted log levels

### DIFF
--- a/src/routes/api/v1/register_username.rs
+++ b/src/routes/api/v1/register_username.rs
@@ -29,7 +29,7 @@ pub async fn register_username(
 		Ok(()) => {},
 		Err(verify::Error::Verification(e)) => {
 			tracing::error!(
-				"Register Verification Error: {}, Payload: {:?}",
+				"Register Verification Error: {}, payload:{:?}",
 				e.detail,
 				payload
 			);
@@ -37,7 +37,7 @@ pub async fn register_username(
 		},
 		Err(e) => {
 			tracing::error!(
-				"Register Server Error: {}, Payload: {:?}",
+				"Register Server Error: {}, payload:{:?}",
 				e.to_string(),
 				payload
 			);
@@ -54,7 +54,7 @@ pub async fn register_username(
 
 	if !username_regex.is_match(&payload.username) {
 		tracing::warn!(
-			"Username does not match the required pattern, Payload: {:?}",
+			"Username does not match the required pattern, payload:{:?}",
 			payload
 		);
 		return Err(ErrorResponse::validation_error(
@@ -63,7 +63,7 @@ pub async fn register_username(
 	}
 
 	blocklist.ensure_valid(&payload.username).map_err(|e| {
-		tracing::warn!("Username is blocked, Payload: {:?}", payload);
+		tracing::warn!("Username is blocked, payload:{:?}", payload);
 		ErrorResponse::validation_error(e.to_string())
 	})?;
 
@@ -78,7 +78,7 @@ pub async fn register_username(
 		.await?;
 
 	if uniqueness_check.username.unwrap_or_default() {
-		tracing::warn!("Username is already taken, Payload: {:?}", payload);
+		tracing::warn!("Username is already taken, payload:{:?}", payload);
 		return Err(ErrorResponse::validation_error(
 			"Username is already taken".to_string(),
 		));
@@ -86,7 +86,7 @@ pub async fn register_username(
 
 	if uniqueness_check.world_id.unwrap_or_default() {
 		tracing::warn!(
-			"This World ID has already registered a username, Payload: {:?}",
+			"This World ID has already registered a username, payload:{:?}",
 			payload
 		);
 		return Err(ErrorResponse::validation_error(

--- a/src/routes/api/v1/register_username.rs
+++ b/src/routes/api/v1/register_username.rs
@@ -53,14 +53,19 @@ pub async fn register_username(
 	};
 
 	if !username_regex.is_match(&payload.username) {
+		tracing::warn!(
+			"Username does not match the required pattern, Payload: {:?}",
+			payload
+		);
 		return Err(ErrorResponse::validation_error(
 			"Username does not match the required pattern".to_string(),
 		));
 	}
 
-	blocklist
-		.ensure_valid(&payload.username)
-		.map_err(|e| ErrorResponse::validation_error(e.to_string()))?;
+	blocklist.ensure_valid(&payload.username).map_err(|e| {
+		tracing::warn!("Username is blocked, Payload: {:?}", payload);
+		ErrorResponse::validation_error(e.to_string())
+	})?;
 
 	let uniqueness_check = sqlx::query!(
 		"SELECT
@@ -73,12 +78,17 @@ pub async fn register_username(
 		.await?;
 
 	if uniqueness_check.username.unwrap_or_default() {
+		tracing::warn!("Username is already taken, Payload: {:?}", payload);
 		return Err(ErrorResponse::validation_error(
 			"Username is already taken".to_string(),
 		));
 	};
 
 	if uniqueness_check.world_id.unwrap_or_default() {
+		tracing::warn!(
+			"This World ID has already registered a username, Payload: {:?}",
+			payload
+		);
 		return Err(ErrorResponse::validation_error(
 			"This World ID has already registered a username.".to_string(),
 		));

--- a/src/routes/api/v1/rename.rs
+++ b/src/routes/api/v1/rename.rs
@@ -73,14 +73,19 @@ pub async fn rename(
 	};
 
 	if !username_regex.is_match(&payload.new_username) {
+		tracing::warn!(
+			"Username does not match the required pattern, Payload: {:?}",
+			payload,
+		);
 		return Err(ErrorResponse::validation_error(
 			"Username does not match the required pattern".to_string(),
 		));
 	}
 
-	blocklist
-		.ensure_valid(&payload.new_username)
-		.map_err(|e| ErrorResponse::validation_error(e.to_string()))?;
+	blocklist.ensure_valid(&payload.new_username).map_err(|e| {
+		tracing::warn!("Blocklist error, Payload: {:?}", payload);
+		ErrorResponse::validation_error(e.to_string())
+	})?;
 
 	let uniqueness_check = sqlx::query!(
 		"SELECT
@@ -97,6 +102,7 @@ pub async fn rename(
 	.await?;
 
 	if uniqueness_check.username.unwrap_or_default() {
+		tracing::warn!("Username is already taken, Payload: {:?}", payload);
 		return Err(ErrorResponse::validation_error(
 			"Username is already taken".to_string(),
 		));

--- a/src/routes/api/v1/rename.rs
+++ b/src/routes/api/v1/rename.rs
@@ -49,7 +49,7 @@ pub async fn rename(
 		Ok(()) => {},
 		Err(verify::Error::Verification(e)) => {
 			tracing::error!(
-				"Rename Verification Error: {}, Payload: {:?}",
+				"Rename Verification Error: {}, payload:{:?}",
 				e.detail,
 				payload
 			);
@@ -57,7 +57,7 @@ pub async fn rename(
 		},
 		Err(e) => {
 			tracing::error!(
-				"Rename Server Error: {}, Payload: {:?}",
+				"Rename Server Error: {}, payload:{:?}",
 				e.to_string(),
 				payload
 			);
@@ -74,7 +74,7 @@ pub async fn rename(
 
 	if !username_regex.is_match(&payload.new_username) {
 		tracing::warn!(
-			"Username does not match the required pattern, Payload: {:?}",
+			"Username does not match the required pattern, payload:{:?}",
 			payload,
 		);
 		return Err(ErrorResponse::validation_error(
@@ -83,7 +83,7 @@ pub async fn rename(
 	}
 
 	blocklist.ensure_valid(&payload.new_username).map_err(|e| {
-		tracing::warn!("Blocklist error, Payload: {:?}", payload);
+		tracing::warn!("Blocklist error, payload:{:?}", payload);
 		ErrorResponse::validation_error(e.to_string())
 	})?;
 
@@ -102,7 +102,7 @@ pub async fn rename(
 	.await?;
 
 	if uniqueness_check.username.unwrap_or_default() {
-		tracing::warn!("Username is already taken, Payload: {:?}", payload);
+		tracing::warn!("Username is already taken, payload:{:?}", payload);
 		return Err(ErrorResponse::validation_error(
 			"Username is already taken".to_string(),
 		));

--- a/src/routes/api/v1/update_record.rs
+++ b/src/routes/api/v1/update_record.rs
@@ -48,7 +48,7 @@ pub async fn update_record(
 		Ok(()) => {},
 		Err(verify::Error::Verification(e)) => {
 			tracing::error!(
-				"Update Record Verification Error: {}, Payload: {:?}",
+				"Update Record Verification Error: {}, payload:{:?}",
 				e.detail,
 				payload
 			);
@@ -56,7 +56,7 @@ pub async fn update_record(
 		},
 		Err(e) => {
 			tracing::error!(
-				"Update Record Server Error: {}, Payload: {:?}",
+				"Update Record Server Error: {}, payload:{:?}",
 				e.to_string(),
 				payload
 			);

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -27,23 +27,21 @@ impl ErrorResponse {
 	}
 
 	pub fn unauthorized(error: String) -> Self {
-		tracing::error!("Unauthorized: {}", error);
+		tracing::warn!("Unauthorized: {}", error);
 		Self {
 			error,
 			status: StatusCode::UNAUTHORIZED,
 		}
 	}
 
-	pub fn validation_error(error: String) -> Self {
-		tracing::error!("Validation Error: {}", error);
+	pub const fn validation_error(error: String) -> Self {
 		Self {
 			error,
 			status: StatusCode::UNPROCESSABLE_ENTITY,
 		}
 	}
 
-	pub fn server_error(error: String) -> Self {
-		tracing::error!("Internal Server Error: {}", error);
+	pub const fn server_error(error: String) -> Self {
 		Self {
 			error,
 			status: StatusCode::INTERNAL_SERVER_ERROR,
@@ -52,7 +50,13 @@ impl ErrorResponse {
 }
 
 impl<E: std::error::Error> From<E> for ErrorResponse {
-	fn from(_: E) -> Self {
+	fn from(e: E) -> Self {
+		// additional, helpful debug info
+		tracing::error!(
+			"Internal Server Error, source: {:?}, error: {}",
+			e.source(),
+			e.to_string()
+		);
 		Self::server_error("Internal Server Error".to_string())
 	}
 }


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
Some error logs trigger opsgenie alerts, when they shouldn't (for example - username already taken) - these were lowered to a warn. Some errors were double logged (in route handlers, and then again in `ErrorResponse` methods - only route handler logs were left because of more context

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
