### PR TITLE
compare lowercase usernames

### DIFF
--- a/src/routes/api/v1/query_single.rs
+++ b/src/routes/api/v1/query_single.rs
@@ -43,7 +43,7 @@ pub async fn query_single(
             created_at as "created_at!",
             updated_at as "updated_at!"
         FROM names 
-        WHERE username = $1 
+        WHERE LOWER(username) = LOWER($1) 
         UNION ALL 
         SELECT 
             username as "username!",
@@ -54,7 +54,7 @@ pub async fn query_single(
             created_at as "created_at!",
             updated_at as "updated_at!"
         FROM names 
-        WHERE address = $1 AND username <> $1
+        WHERE address = $1 AND LOWER(username) <> LOWER($1)
         "#,
 		validated_input
 	)


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

What @sevazhidkov found out was that the query matched using the gist index, instead of btree. `lower()` fixes that. Btree is much faster

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
