### PR TITLE
Refactor docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,47 @@
-# Use a specific version of clux/muslrust
-FROM --platform=linux/amd64 clux/muslrust:stable AS builder
+# ---- Builder Stage ----
+FROM --platform=linux/amd64 rust:1.81 AS builder
 
-RUN ln -s /usr/bin/ar /usr/bin/musl-ar
+# Install additional build dependencies required by aws-lc-sys
+RUN apt-get update && \
+    apt-get install -y \
+      cmake \
+      pkg-config \
+      git \
+      build-essential \
+      ninja-build \
+      python3 \
+      libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
 
-WORKDIR /wld-usernames
-COPY . .
-
-ENV AR=musl-ar
+# Set the working directory
+WORKDIR /app
 
 ARG SQLX_OFFLINE
 ENV SQLX_OFFLINE=${SQLX_OFFLINE}
 
+# Copy the entire source code into the container
+COPY . .
+
+# Build the application in release mode
 RUN cargo build --release --bin wld-usernames
 
-FROM --platform=linux/amd64 alpine AS runtime
-WORKDIR /wld-usernames
-COPY --from=builder /wld-usernames/target/x86_64-unknown-linux-musl/release/wld-usernames /usr/local/bin
+# ---- Runtime Stage ----
+FROM --platform=linux/amd64 debian:bookworm-slim AS runtime
 
+# Install runtime dependencies (CA certificates and libssl3 for OpenSSL 3)
+RUN apt-get update && \
+    apt-get install -y ca-certificates libssl3 && \
+    rm -rf /var/lib/apt/lists/*
+
+# Set the working directory in the runtime container
+WORKDIR /app
+
+# Copy the built binary from the builder stage
+COPY --from=builder /app/target/release/wld-usernames /usr/local/bin/wld-usernames
+
+# Expose the port your server listens on 
 EXPOSE 8000
 ENTRYPOINT ["/usr/local/bin/wld-usernames"]
 
 HEALTHCHECK --interval=5m \
-    CMD curl -f http://localhost:8000/ || exit 1
+    CMD curl -f http://localhost:8001/ || exit 1

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ EXPOSE 8000
 ENTRYPOINT ["/usr/local/bin/wld-usernames"]
 
 HEALTHCHECK --interval=5m \
-    CMD curl -f http://localhost:8001/ || exit 1
+    CMD curl -f http://localhost:8000/ || exit 1


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

This PR refactors the Dockerfile by:

- Switching to the official rust:1.81 image (pinned) to eliminate cross-device link errors and remove musl dependencies.
- Adding necessary build tools (cmake, pkg-config, ninja-build, etc.) for aws‑lc‑sys.
- Updating the runtime stage to use debian:bookworm-slim for proper dynamic library support (libssl.so.3) and adding a healthcheck.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
