### PR TITLE
Add an endpoint that redirects to the user's avatar

### DIFF
--- a/.sqlx/query-cb225a26fa94514498c7aff0786bd09fb42ef1fe133a4c1b4d1922e3ce80dc61.json
+++ b/.sqlx/query-cb225a26fa94514498c7aff0786bd09fb42ef1fe133a4c1b4d1922e3ce80dc61.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT username, profile_picture_url FROM names WHERE LOWER(username) = LOWER($1)",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "username",
+        "type_info": "Varchar"
+      },
+      {
+        "ordinal": 1,
+        "name": "profile_picture_url",
+        "type_info": "Varchar"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "cb225a26fa94514498c7aff0786bd09fb42ef1fe133a4c1b4d1922e3ce80dc61"
+}

--- a/src/routes/api/v1/avatar.rs
+++ b/src/routes/api/v1/avatar.rs
@@ -1,0 +1,80 @@
+use axum::{
+	extract::{Path, Query},
+	response::{IntoResponse, Redirect, Response},
+	Extension,
+};
+use redis::{aio::ConnectionManager, AsyncCommands};
+use tracing::{info_span, Instrument};
+
+use crate::{
+	config::Db,
+	types::{AvatarQueryParams, ErrorResponse, MovedRecord},
+	utils::ONE_MINUTE_IN_SECONDS,
+};
+
+#[tracing::instrument(skip_all)]
+pub async fn avatar(
+	Extension(db): Extension<Db>,
+	Extension(mut redis): Extension<ConnectionManager>,
+	Query(params): Query<AvatarQueryParams>,
+	Path(name): Path<String>,
+) -> Result<Response, ErrorResponse> {
+	let cache_key = format!("avatar:{name}");
+
+	if let Ok(avatar_url) = redis.get::<_, String>(&cache_key).await {
+		return Ok(Redirect::temporary(&avatar_url).into_response());
+	}
+
+	if let Some(record) = sqlx::query!(
+		"SELECT username, profile_picture_url FROM names WHERE LOWER(username) = LOWER($1)",
+		name
+	)
+	.fetch_optional(&db.read_only)
+	.instrument(info_span!("avatar_db_query", input = name))
+	.await?
+	{
+		if let Some(profile_picture_url) = record.profile_picture_url {
+			redis
+				.set_ex(
+					&cache_key,
+					&profile_picture_url,
+					ONE_MINUTE_IN_SECONDS * 60 * 24 * 7,
+				)
+				.await?;
+
+			return Ok(Redirect::temporary(&profile_picture_url).into_response());
+		}
+	}
+
+	if let Some(moved) = sqlx::query_as!(
+		MovedRecord,
+		"SELECT * FROM old_names WHERE old_username = $1",
+		name
+	)
+	.fetch_optional(&db.read_only)
+	.instrument(info_span!("avatar_moved_db_query", username = name))
+	.await?
+	{
+		return Ok(
+			Redirect::permanent(&format!("/api/v1/avatar/{}", moved.new_username)).into_response(),
+		);
+	}
+
+	if let Some(fallback) = params.fallback {
+		return Ok(Redirect::temporary(fallback.as_str()).into_response());
+	}
+
+	Err(ErrorResponse::not_found("Record not found.".to_string()))
+}
+
+pub fn docs(op: aide::transform::TransformOperation) -> aide::transform::TransformOperation {
+	op.description("Redirect to the user's avatar, optionally falling back to a default.")
+		.response_with::<404, ErrorResponse, _>(|op| {
+			op.description(
+				"Returned when the user has no avatar and a fallback image is not provided.",
+			)
+		})
+		.response_with::<301, Redirect, _>(|op| {
+			op.description("A redirect to the user's avatar or the fallback avatar.")
+		})
+}

--- a/src/routes/api/v1/mod.rs
+++ b/src/routes/api/v1/mod.rs
@@ -3,6 +3,7 @@ use aide::axum::{
 	ApiRouter,
 };
 
+mod avatar;
 mod ens_gateway;
 mod query_multiple;
 mod query_single;
@@ -11,6 +12,7 @@ mod rename;
 mod search;
 mod update_record;
 
+use avatar::{avatar, docs as avatar_docs};
 use ens_gateway::{docs as ens_gateway_docs, ens_gateway_get, ens_gateway_post};
 use http::Method;
 use query_multiple::{docs as query_multiple_docs, query_multiple};
@@ -38,6 +40,8 @@ pub fn handler() -> ApiRouter {
 		)
 		.layer(cors.clone())
 		.api_route("/query", post_with(query_multiple, query_multiple_docs))
+		.layer(cors.clone())
+		.api_route("/avatar/:name", get_with(avatar, avatar_docs))
 		.layer(cors.clone())
 		.api_route("/rename", post_with(rename, rename_docs))
 		.api_route(

--- a/src/routes/docs.rs
+++ b/src/routes/docs.rs
@@ -2,7 +2,7 @@ use aide::{axum::ApiRouter, openapi::OpenApi, scalar::Scalar};
 use axum::{routing::get, Extension, Json};
 
 pub fn handler() -> ApiRouter {
-	let scalar = Scalar::new("/openapi.json").with_title("Orbit Docs");
+	let scalar = Scalar::new("/openapi.json").with_title("World App Username API Docs");
 
 	ApiRouter::new()
 		.route("/docs", scalar.axum_route())

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -9,8 +9,8 @@ pub use database::{MovedAddress, MovedRecord, Name, NameSearch};
 pub use ens::{resolveCall as ResolveRequest, Method};
 pub use error::{ENSErrorResponse, ErrorResponse};
 pub use request::{
-	ENSQueryPayload, QueryAddressesPayload, RegisterUsernamePayload, RenamePayload,
-	UpdateUsernamePayload,
+	AvatarQueryParams, ENSQueryPayload, QueryAddressesPayload, RegisterUsernamePayload,
+	RenamePayload, UpdateUsernamePayload,
 };
 pub use response::{ENSResponse, UsernameRecord};
 pub use wrappers::{Address, VerificationLevel};

--- a/src/types/request.rs
+++ b/src/types/request.rs
@@ -42,6 +42,12 @@ pub struct QueryAddressesPayload {
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
+pub struct AvatarQueryParams {
+	/// The URL to redirect to if the username is not found or does not have a profile picture URL.
+	pub fallback: Option<Url>,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct UpdateUsernamePayload {
 	/// 0x-prefixed hex string of the World ID proof.
 	proof: String,


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Add a new endpoint at `/api/v1/avatar/:name`, which redirects to the user's avatar, with the following logic:

- If the username exists and has a profile picture, we cache the result and return a redirect to it
- If the username exists but doesn't have a profile picture, we redirect to the fallback url if provided or 404 if not
- If the username doesn't exist but used to, we redirect to this endpoint again with the new username
- If the username doesn't exist and never did, we redirect to the fallback url if provided or 404 if not

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [x] I have updated the documentation as needed.
