### PR TITLE
Fix: account_deletion instead of user_deletion

### DIFF
--- a/src/data_deletion_worker/deletion_request_queue.rs
+++ b/src/data_deletion_worker/deletion_request_queue.rs
@@ -143,7 +143,7 @@ impl DeletionRequestQueueImpl {
 	}
 
 	fn is_valid_message_type(message_type: &str) -> bool {
-		matches!(message_type, "data_deletion" | "user_deletion")
+		matches!(message_type, "data_deletion" | "account_deletion")
 	}
 
 	async fn discard_unknown_message_types(&self, message: QueueMessage) -> Option<QueueMessage> {


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description
This pull request includes a change to the `is_valid_message_type` function in the `DeletionRequestQueueImpl` implementation. The change updates the valid message types to include "account_deletion" instead of "user_deletion".

* [`src/data_deletion_worker/deletion_request_queue.rs`](diffhunk://#diff-3d33703596e91d885029a956b2610cf08bb8c31eed9dbdbb65f8e6c62f3ee432L146-R146): Modified the `is_valid_message_type` function to recognize "account_deletion" as a valid message type instead of "user_deletion".
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
