### PR TITLE
feat: Add fallback URL whitelisting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,7 @@ pub struct Config {
 	pub ens_domain: String,
 	pub private_key: String,
 	pub developer_portal_url: String,
+	pub whitelisted_avatar_domains: Option<Vec<String>>,
 	db_client: Option<PgPool>,
 	db_read_client: Option<PgPool>,
 	redis_pool: Option<ConnectionManagerDebug>,
@@ -87,6 +88,14 @@ impl Config {
 			&env::var("BLOCKED_SUBSTRINGS")
 				.context("BLOCKED_SUBSTRINGS environment variable not set")?,
 		);
+
+		let whitelisted_avatar_domains =
+			env::var("WHITELISTED_AVATAR_DOMAINS").ok().map(|domains| {
+				domains
+					.split(',')
+					.map(|s| s.trim().to_lowercase())
+					.collect()
+			});
 
 		let db_client = PgPoolOptions::new()
 			.max_connections(50)
@@ -143,6 +152,7 @@ impl Config {
 			developer_portal_url: env::var("DEVELOPER_PORTAL_ENDPOINT")
 				.context("DEVELOPER_PORTAL_ENDPOINT environment variable not set")?,
 			redis_pool: Some(ConnectionManagerDebug::from(redis_pool)),
+			whitelisted_avatar_domains,
 		})
 	}
 

--- a/src/routes/api/v1/avatar.rs
+++ b/src/routes/api/v1/avatar.rs
@@ -100,7 +100,16 @@ fn fallback_response(fallback: Option<Url>, error_msg: String, config: &Config) 
 			// Check if the fallback URL's domain is in the whitelist
 			if let Some(domain) = fallback.host_str() {
 				let domain = domain.to_lowercase();
-				let whitelist = config.whitelisted_avatar_domains.as_ref().unwrap();
+				let whitelist = match config.whitelisted_avatar_domains.as_ref() {
+					Some(list) => list,
+					None => {
+						return ErrorResponse::forbidden(
+							"Fallback URLs are not allowed when whitelist is not configured"
+								.to_string(),
+						)
+						.into_response()
+					},
+				};
 
 				// Check if the domain exactly matches a whitelisted domain
 				// or is a subdomain of a whitelisted domain

--- a/src/routes/api/v1/avatar.rs
+++ b/src/routes/api/v1/avatar.rs
@@ -91,7 +91,7 @@ fn fallback_response(fallback: Option<Url>, error_msg: String, config: &Config) 
 		|fallback| {
 			// If whitelist is not set, block all fallback URLs
 			if config.whitelisted_avatar_domains.is_none() {
-				return ErrorResponse::not_found(
+				return ErrorResponse::forbidden(
 					"Fallback URLs are not allowed when whitelist is not configured".to_string(),
 				)
 				.into_response();
@@ -113,7 +113,7 @@ fn fallback_response(fallback: Option<Url>, error_msg: String, config: &Config) 
 			}
 
 			// If domain is not whitelisted or host is missing, return error
-			ErrorResponse::not_found("Fallback URL domain is not whitelisted".to_string())
+			ErrorResponse::forbidden("Fallback URL domain is not whitelisted".to_string())
 				.into_response()
 		},
 	)
@@ -123,7 +123,12 @@ pub fn docs(op: aide::transform::TransformOperation) -> aide::transform::Transfo
 	op.description("Redirect to the user's avatar, optionally falling back to a default. The fallback URL must be from a whitelisted domain specified in the WHITELISTED_AVATAR_DOMAINS environment variable.")
 		.response_with::<404, ErrorResponse, _>(|op| {
 			op.description(
-				"Returned when the user has no avatar and a fallback image is not provided, or when the fallback URL's domain is not whitelisted.",
+				"Returned when the user has no avatar and a fallback image is not provided.",
+			)
+		})
+		.response_with::<403, ErrorResponse, _>(|op| {
+			op.description(
+				"Returned when the fallback URL's domain is not whitelisted or when fallback URLs are not allowed (whitelist not configured).",
 			)
 		})
 		.response_with::<301, Redirect, _>(|op| {

--- a/src/routes/api/v1/avatar.rs
+++ b/src/routes/api/v1/avatar.rs
@@ -8,7 +8,7 @@ use tracing::{info_span, Instrument};
 use url::Url;
 
 use crate::{
-	config::Db,
+	config::{Config, Db},
 	types::{AvatarQueryParams, ErrorResponse, MovedRecord},
 	utils::ONE_MINUTE_IN_SECONDS,
 };
@@ -17,6 +17,7 @@ use crate::{
 pub async fn avatar(
 	Extension(db): Extension<Db>,
 	Extension(mut redis): Extension<ConnectionManager>,
+	Extension(config): Extension<Config>,
 	Query(params): Query<AvatarQueryParams>,
 	Path(name): Path<String>,
 ) -> Result<Response, ErrorResponse> {
@@ -59,6 +60,7 @@ pub async fn avatar(
 		return Ok(fallback_response(
 			params.fallback,
 			"Avatar not set".to_string(),
+			&config,
 		));
 	}
 
@@ -79,24 +81,52 @@ pub async fn avatar(
 	Ok(fallback_response(
 		params.fallback,
 		"Record not found".to_string(),
+		&config,
 	))
 }
 
-fn fallback_response(fallback: Option<Url>, error_msg: String) -> Response {
+fn fallback_response(fallback: Option<Url>, error_msg: String, config: &Config) -> Response {
 	fallback.map_or_else(
 		|| ErrorResponse::not_found(error_msg).into_response(),
-		|fallback| Redirect::temporary(fallback.as_str()).into_response(),
+		|fallback| {
+			// If whitelist is not set, block all fallback URLs
+			if config.whitelisted_avatar_domains.is_none() {
+				return ErrorResponse::not_found(
+					"Fallback URLs are not allowed when whitelist is not configured".to_string(),
+				)
+				.into_response();
+			}
+
+			// Check if the fallback URL's domain is in the whitelist
+			if let Some(domain) = fallback.host_str() {
+				let domain = domain.to_lowercase();
+				let whitelist = config.whitelisted_avatar_domains.as_ref().unwrap();
+
+				// Check if the domain exactly matches a whitelisted domain
+				// or is a subdomain of a whitelisted domain
+				if whitelist
+					.iter()
+					.any(|allowed| domain == *allowed || domain.ends_with(&format!(".{}", allowed)))
+				{
+					return Redirect::temporary(fallback.as_str()).into_response();
+				}
+			}
+
+			// If domain is not whitelisted or host is missing, return error
+			ErrorResponse::not_found("Fallback URL domain is not whitelisted".to_string())
+				.into_response()
+		},
 	)
 }
 
 pub fn docs(op: aide::transform::TransformOperation) -> aide::transform::TransformOperation {
-	op.description("Redirect to the user's avatar, optionally falling back to a default.")
+	op.description("Redirect to the user's avatar, optionally falling back to a default. The fallback URL must be from a whitelisted domain specified in the WHITELISTED_AVATAR_DOMAINS environment variable.")
 		.response_with::<404, ErrorResponse, _>(|op| {
 			op.description(
-				"Returned when the user has no avatar and a fallback image is not provided.",
+				"Returned when the user has no avatar and a fallback image is not provided, or when the fallback URL's domain is not whitelisted.",
 			)
 		})
 		.response_with::<301, Redirect, _>(|op| {
-			op.description("A redirect to the user's avatar or the fallback avatar.")
+			op.description("A redirect to the user's avatar or the fallback avatar (if from a whitelisted domain).")
 		})
 }

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -47,6 +47,13 @@ impl ErrorResponse {
 			status: StatusCode::INTERNAL_SERVER_ERROR,
 		}
 	}
+
+	pub const fn forbidden(error: String) -> Self {
+		Self {
+			error,
+			status: StatusCode::FORBIDDEN,
+		}
+	}
 }
 
 impl<E: std::error::Error> From<E> for ErrorResponse {


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description
Ticket - [DEV-1722](https://linear.app/worldcoin/issue/DEV-1722/h1-usernamesworldcoindev-open-redirect)
Introduces whitelisting for fallback URLs in the `/avatar` endpoint.
If the fallback URL does not match any of the whitelisted domains, the request will be rejected with 403 Forbidden.
<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [x] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
