### PR TITLE
feat: Add retry logic to verify calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1407,11 +1407,13 @@ dependencies = [
 
 [[package]]
 name = "backon"
-version = "1.3.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5289ec98f68f28dd809fd601059e6aa908bb8f6108620930828283d4ee23d7"
+checksum = "302eaff5357a264a2c42f127ecb8bac761cf99749fc3dc95677e2743991f99e7"
 dependencies = [
  "fastrand",
+ "gloo-timers",
+ "tokio",
 ]
 
 [[package]]
@@ -2429,6 +2431,18 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "group"
@@ -6446,6 +6460,7 @@ dependencies = [
  "aws-sdk-sqs",
  "axum",
  "axum-jsonschema",
+ "backon",
  "chrono",
  "datadog-tracing",
  "dotenvy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ uuid = { version = "1.7.0", features = ["serde", "v4"] }
 once_cell = "1.19.0"
 opensearch = { version = "2.2.0", features = ["aws-auth", "rustls-tls"] }
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
+backon = "1.5.1"
 
 
 [build-dependencies]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,7 +1,8 @@
+use backon::{ExponentialBuilder, Retryable};
+use idkit::{hashing::hash_to_field, session::VerificationLevel, Proof};
 use reqwest::{header, StatusCode};
 use serde::Serialize;
-
-use idkit::{hashing::hash_to_field, session::VerificationLevel, Proof};
+use std::time::Duration;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
@@ -12,21 +13,17 @@ pub enum Error {
 	#[error("failed to decode response: {0}")]
 	Serde(#[from] serde_json::Error),
 	#[error("unexpected response: {status}, body: {body}")]
-	InvalidResponse {
-		status: reqwest::StatusCode,
-		body: String,
-	},
+	InvalidResponse { status: StatusCode, body: String },
 }
 
 #[derive(Debug, serde::Deserialize)]
-#[allow(dead_code)] // Fields are used on the HTTP response
 pub struct ErrorResponse {
 	pub code: String,
 	pub detail: String,
 	pub attribute: Option<String>,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Clone)]
 struct VerificationRequest {
 	action: String,
 	proof: String,
@@ -49,37 +46,59 @@ pub async fn dev_portal_verify_proof<V: alloy::sol_types::SolValue + Send>(
 	signal: V,
 	developer_portal_url: String,
 ) -> Result<(), Error> {
-	let signal = signal.abi_encode_packed();
+	let packed = signal.abi_encode_packed();
+	let signal_hash = if packed.is_empty() {
+		None
+	} else {
+		Some(format!("0x{:x}", hash_to_field(&packed)))
+	};
 
-	let response = reqwest::Client::new()
-		.post(format!("{developer_portal_url}/api/v2/verify/{app_id}"))
-		.header(header::USER_AGENT, "idkit-rs")
-		.json(&VerificationRequest {
-			proof: proof.proof,
-			signal_hash: if signal.is_empty() {
-				None
-			} else {
-				Some(format!("0x{:x}", hash_to_field(&signal)))
+	let body = VerificationRequest {
+		action: action.to_owned(),
+		proof: proof.proof.clone(),
+		merkle_root: proof.merkle_root.clone(),
+		nullifier_hash: proof.nullifier_hash.clone(),
+		verification_level: proof.verification_level,
+		signal_hash,
+	};
+
+	let client = reqwest::Client::new();
+	let url = format!("{developer_portal_url}/api/v2/verify/{app_id}");
+
+	let policy = ExponentialBuilder::default()
+		.with_min_delay(Duration::from_millis(100))
+		.with_max_delay(Duration::from_secs(2))
+		.with_jitter()
+		.with_max_times(3);
+
+	let attempt = || async {
+		let resp = client
+			.post(&url)
+			.header(header::USER_AGENT, "idkit-rs")
+			.json(&body)
+			.send()
+			.await?;
+
+		match resp.status() {
+			StatusCode::OK => Ok(()),
+			StatusCode::BAD_REQUEST => {
+				let err = resp.json::<ErrorResponse>().await?;
+				Err(Error::Verification(err))
 			},
-			action: action.to_string(),
-			merkle_root: proof.merkle_root,
-			nullifier_hash: proof.nullifier_hash,
-			verification_level: proof.verification_level,
-		})
-		.send()
+			status => {
+				let text = resp.text().await.unwrap_or_default();
+				Err(Error::InvalidResponse { status, body: text })
+			},
+		}
+	};
+
+	attempt
+		.retry(policy)
+		.sleep(tokio::time::sleep)
+		.when(
+			|e: &Error| matches!(e, Error::InvalidResponse { status, .. } if status.is_server_error()),
+		)
 		.await?;
 
-	match response.status() {
-		StatusCode::OK => Ok(()),
-		StatusCode::BAD_REQUEST => {
-			Err(Error::Verification(response.json::<ErrorResponse>().await?))
-		},
-		status => {
-			let body = response
-				.text()
-				.await
-				.unwrap_or_else(|e| format!("Failed to read body: {e}"));
-			Err(Error::InvalidResponse { status, body })
-		},
-	}
+	Ok(())
 }


### PR DESCRIPTION
## PR Type

- [x] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

Ticket - [DEV-1849](https://linear.app/worldcoin/issue/DEV-1849/usernames-unexpected-response-errors).

Adds retry logic to verify requests - exponential backoff with jitter and 3 retries.

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
