### PR TITLE
docs(readme): clarify profile picture availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This is our open source implementation of ENS compatible Usernames
 
+> Note: Profile pictures are currently an internal preview feature, are not generally available, and should not be considered part of the supported public product surface.
+
 ## Prerequisite
 
 In order to use `sqlx` commands, you need to install `sqlx-cli`


### PR DESCRIPTION
This PR ...

- clarifies that profile pictures are an internal preview feature
- states that the feature is not generally available or part of the supported public product surface