### PR TITLE
feat: add dev/internal endpoint to delete a username record

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,8 @@ PROFILE_PICTURE_CDN_URL=""
 # Attestation
 ATTESTATION_JWKS_URL="https://attestation.worldcoin.dev/.well-known/jwks.json"
 
+INTERNAL_API_SECRET=
+
 
 # SQS Configuration
 ENV=local

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7068,6 +7068,7 @@ dependencies = [
  "sha2",
  "sqlx",
  "sqlxinsert",
+ "subtle",
  "thiserror 1.0.69",
  "tokio",
  "tower 0.5.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,7 @@ k256 = "0.13.4"
 jsonwebtoken = { version = "10.0.0", features = ["aws_lc_rs"] }
 sha2 = "0.10.9"
 multer = "3.1.0"
+subtle = "2.6.1"
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/README.md
+++ b/README.md
@@ -37,10 +37,16 @@ cargo sqlx prepare
 ## 🧪 Dev/E2E Endpoints
 
 The following endpoints are intended for local development and e2e tests
-only. They are gated by the same flag as `x-e2e-skip-attestation`: the
-service must run with `APP_ENV=development` or `APP_ENV=staging`, **and** the
-caller must send `x-e2e-skip-attestation: true`. In production they always
-respond with `403 Forbidden`.
+only. They are gated by **three** conditions, all of which must hold:
+
+1. The service runs with `APP_ENV=development` or `APP_ENV=staging`
+   (production always returns `403 Forbidden`).
+2. The caller sends `x-e2e-skip-attestation: true`.
+3. The caller sends `x-internal-api-secret: <secret>` whose value matches the
+   `INTERNAL_API_SECRET` env var configured on the server. The secret is
+   compared in constant time. If `INTERNAL_API_SECRET` is unset or empty on
+   the server, every internal endpoint fails closed (403) regardless of the
+   other conditions.
 
 - `DELETE /api/v1/internal/usernames/:address` — deletes the username record
   associated with a wallet address (idempotent). Wraps the same

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ cargo sqlx prepare
 [Production Deployment](https://usernames.worldcoin.org/docs)
 [ENS Resolver](https://etherscan.io/address/0xB4E36A6C3403137d8fdaf4e91b91D1aBC2caF3Dd)
 
+## 🧪 Dev/E2E Endpoints
+
+The following endpoints are intended for local development and e2e tests
+only. They are gated by the same flag as `x-e2e-skip-attestation`: the
+service must run with `APP_ENV=development` or `APP_ENV=staging`, **and** the
+caller must send `x-e2e-skip-attestation: true`. In production they always
+respond with `403 Forbidden`.
+
+- `DELETE /api/v1/internal/usernames/:address` — deletes the username record
+  associated with a wallet address (idempotent). Wraps the same
+  `UsernameDeletionService` used by the deletion worker, so it cleans up
+  `names`, `old_names` and the related Redis cache entries. Returns
+  `204 No Content` on success.
+
 ### Rust required installations
 
 ```bash

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,10 @@ pub struct Config {
 	pub attestation_jwks_url: String,
 	pub whitelisted_avatar_domains: Option<Vec<String>>,
 	pub environment: Environment,
+	/// Shared secret for `/api/v1/internal/*` endpoints. Loaded from the
+	/// `INTERNAL_API_SECRET` env var. `None` when unset or empty, in which case
+	/// every internal endpoint must respond with 403 regardless of `APP_ENV`.
+	internal_api_secret: Option<String>,
 	db_client: Option<PgPool>,
 	db_read_client: Option<PgPool>,
 	redis_pool: Option<ConnectionManagerDebug>,
@@ -172,6 +176,10 @@ impl Config {
 			}
 		}
 
+		let internal_api_secret = env::var("INTERNAL_API_SECRET")
+			.ok()
+			.filter(|s| !s.is_empty());
+
 		Ok(Self {
 			environment,
 			db_client: Some(db_client),
@@ -192,6 +200,7 @@ impl Config {
 				.context("ATTESTATION_JWKS_URL environment variable not set")?,
 			redis_pool: Some(ConnectionManagerDebug::from(redis_pool)),
 			whitelisted_avatar_domains,
+			internal_api_secret,
 			s3_client,
 		})
 	}
@@ -242,6 +251,16 @@ impl Config {
 		self.environment == Environment::Development || self.environment == Environment::Staging
 	}
 
+	/// Returns the configured internal API shared secret, if any.
+	///
+	/// `None` means the shared-secret env var was unset or empty at startup.
+	/// Callers protecting `/api/v1/internal/*` endpoints MUST treat `None` as
+	/// "fail-closed" (i.e. respond 403) so that a missing secret in
+	/// dev/staging never leaves the endpoints reachable without authn.
+	pub fn internal_api_secret(&self) -> Option<&str> {
+		self.internal_api_secret.as_deref()
+	}
+
 	#[cfg(test)]
 	pub fn test_config(env: Environment) -> Self {
 		use idkit::session::AppId;
@@ -254,6 +273,7 @@ impl Config {
 			developer_portal_url: "http://test.com".to_string(),
 			attestation_jwks_url: "http://test.com/jwks".to_string(),
 			whitelisted_avatar_domains: None,
+			internal_api_secret: None,
 			db_client: None,
 			db_read_client: None,
 			redis_pool: None,

--- a/src/data_deletion_worker/mod.rs
+++ b/src/data_deletion_worker/mod.rs
@@ -9,10 +9,14 @@ use redis::aio::ConnectionManager;
 use sqlx::postgres::PgPoolOptions;
 use std::{env, time::Duration};
 
+pub use username_deletion_service::{UsernameDeletionService, UsernameDeletionServiceImpl};
+
+#[cfg(test)]
+pub use error::QueueError;
+
 use self::{
 	deletion_completion_queue::DeletionCompletionQueueImpl,
-	deletion_request_queue::DeletionRequestQueueImpl,
-	username_deletion_service::UsernameDeletionServiceImpl, worker::DataDeletionWorker,
+	deletion_request_queue::DeletionRequestQueueImpl, worker::DataDeletionWorker,
 };
 
 pub async fn init_deletion_worker(

--- a/src/routes/api/v1/internal/delete_username.rs
+++ b/src/routes/api/v1/internal/delete_username.rs
@@ -1,0 +1,248 @@
+use aide::transform::TransformOperation;
+use axum::{
+	extract::Path,
+	http::{HeaderMap, StatusCode},
+	Extension,
+};
+use redis::aio::ConnectionManager;
+use tracing::{info, instrument, warn};
+
+use crate::{
+	config::{ConfigExt, Db},
+	data_deletion_worker::{UsernameDeletionService, UsernameDeletionServiceImpl},
+	types::ErrorResponse,
+};
+
+pub(super) const SKIP_ATTESTATION_HEADER: &str = "x-e2e-skip-attestation";
+
+/// Returns `true` when the request is allowed to use the dev/internal endpoint:
+/// the runtime environment must allow skipping attestation (Development or Staging),
+/// and the request must carry `x-e2e-skip-attestation: true`.
+pub(super) fn is_e2e_skip_allowed(
+	allowed_to_skip_attestation: bool,
+	headers: &HeaderMap,
+) -> bool {
+	let header_present = headers
+		.get(SKIP_ATTESTATION_HEADER)
+		.and_then(|v| v.to_str().ok())
+		.is_some_and(|v| v == "true");
+
+	allowed_to_skip_attestation && header_present
+}
+
+/// Pure handler logic, decoupled from axum extensions for testability.
+///
+/// Returns 403 if the request fails the dev/e2e gate, 500 if the deletion
+/// service errors, and 204 otherwise. The deletion is idempotent – missing
+/// rows are not an error.
+async fn handle_delete_username(
+	service: &dyn UsernameDeletionService,
+	allowed_to_skip_attestation: bool,
+	headers: &HeaderMap,
+	address: &str,
+) -> Result<StatusCode, ErrorResponse> {
+	if !is_e2e_skip_allowed(allowed_to_skip_attestation, headers) {
+		warn!("Dev delete_username endpoint called without valid e2e skip context");
+		return Err(ErrorResponse::forbidden(
+			"This endpoint is only available in dev/e2e contexts.".to_string(),
+		));
+	}
+
+	service.delete_username(address).await.map_err(|e| {
+		tracing::error!(
+			"Dev delete_username failed for {}: {}",
+			address,
+			e.to_string()
+		);
+		ErrorResponse::server_error("Failed to delete username record".to_string())
+	})?;
+
+	info!(address = %address, "Dev/internal delete_username succeeded");
+	Ok(StatusCode::NO_CONTENT)
+}
+
+/// Dev/internal endpoint: deletes a username record by wallet address.
+///
+/// Intended for use by app-backend e2e tests to clean up rows created via
+/// `POST /v1/usernames/register`. It is gated by the same dev/e2e config flag
+/// pattern used for `x-e2e-skip-attestation`: callers must run in Development
+/// or Staging **and** send `x-e2e-skip-attestation: true`. Any other case
+/// returns 403 Forbidden.
+///
+/// On success returns 204 No Content. The underlying delete is idempotent –
+/// missing rows are not an error.
+#[instrument(skip_all, fields(wallet_address = %address))]
+pub async fn delete_username(
+	Extension(config): ConfigExt,
+	Extension(db): Extension<Db>,
+	Extension(redis): Extension<ConnectionManager>,
+	headers: HeaderMap,
+	Path(address): Path<String>,
+) -> Result<StatusCode, ErrorResponse> {
+	let service = UsernameDeletionServiceImpl::new(db.read_write.clone(), redis.clone());
+	handle_delete_username(
+		&service,
+		config.allowed_to_skip_attestation(),
+		&headers,
+		&address,
+	)
+	.await
+}
+
+pub fn docs(op: TransformOperation) -> TransformOperation {
+	op.description(
+		"Dev/internal endpoint to delete a username record by wallet address. \
+		 Available only in Development/Staging environments and only when the \
+		 `x-e2e-skip-attestation: true` header is present. Intended for e2e \
+		 test cleanup; idempotent.",
+	)
+}
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+	use crate::data_deletion_worker::QueueError;
+	use async_trait::async_trait;
+	use axum::http::HeaderValue;
+	use axum::response::IntoResponse;
+	use std::sync::{
+		atomic::{AtomicUsize, Ordering},
+		Arc,
+	};
+
+	#[test]
+	fn rejects_when_env_not_allowed() {
+		let mut headers = HeaderMap::new();
+		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static("true"));
+		assert!(!is_e2e_skip_allowed(false, &headers));
+	}
+
+	#[test]
+	fn rejects_when_header_missing() {
+		let headers = HeaderMap::new();
+		assert!(!is_e2e_skip_allowed(true, &headers));
+	}
+
+	#[test]
+	fn rejects_when_header_is_not_true() {
+		let mut headers = HeaderMap::new();
+		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static("false"));
+		assert!(!is_e2e_skip_allowed(true, &headers));
+	}
+
+	#[test]
+	fn rejects_when_header_is_empty() {
+		let mut headers = HeaderMap::new();
+		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static(""));
+		assert!(!is_e2e_skip_allowed(true, &headers));
+	}
+
+	#[test]
+	fn allows_when_env_and_header_set() {
+		let mut headers = HeaderMap::new();
+		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static("true"));
+		assert!(is_e2e_skip_allowed(true, &headers));
+	}
+
+	#[derive(Default)]
+	struct MockService {
+		calls: AtomicUsize,
+		fail: bool,
+	}
+
+	#[async_trait]
+	impl UsernameDeletionService for MockService {
+		async fn delete_username(&self, _wallet_address: &str) -> Result<(), QueueError> {
+			self.calls.fetch_add(1, Ordering::SeqCst);
+			if self.fail {
+				Err(QueueError::CacheInvalidationError("mock failure".into()))
+			} else {
+				Ok(())
+			}
+		}
+	}
+
+	fn headers_with_skip(value: &'static str) -> HeaderMap {
+		let mut headers = HeaderMap::new();
+		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static(value));
+		headers
+	}
+
+	#[tokio::test]
+	async fn handler_returns_forbidden_in_production_even_with_header() {
+		let service = Arc::new(MockService::default());
+		let headers = headers_with_skip("true");
+
+		let result = handle_delete_username(
+			service.as_ref(),
+			false,
+			&headers,
+			"0x0000000000000000000000000000000000000001",
+		)
+		.await;
+
+		let response = result.expect_err("should be forbidden").into_response();
+		assert_eq!(response.status(), StatusCode::FORBIDDEN);
+		assert_eq!(
+			service.calls.load(Ordering::SeqCst),
+			0,
+			"deletion service must not be called when forbidden"
+		);
+	}
+
+	#[tokio::test]
+	async fn handler_returns_forbidden_in_dev_without_header() {
+		let service = Arc::new(MockService::default());
+		let headers = HeaderMap::new();
+
+		let result = handle_delete_username(
+			service.as_ref(),
+			true,
+			&headers,
+			"0x0000000000000000000000000000000000000001",
+		)
+		.await;
+
+		let response = result.expect_err("should be forbidden").into_response();
+		assert_eq!(response.status(), StatusCode::FORBIDDEN);
+		assert_eq!(service.calls.load(Ordering::SeqCst), 0);
+	}
+
+	#[tokio::test]
+	async fn handler_calls_service_and_returns_no_content_on_success() {
+		let service = Arc::new(MockService::default());
+		let headers = headers_with_skip("true");
+
+		let result = handle_delete_username(
+			service.as_ref(),
+			true,
+			&headers,
+			"0xabCDEF0000000000000000000000000000000123",
+		)
+		.await;
+
+		assert_eq!(result.unwrap(), StatusCode::NO_CONTENT);
+		assert_eq!(service.calls.load(Ordering::SeqCst), 1);
+	}
+
+	#[tokio::test]
+	async fn handler_returns_server_error_when_service_fails() {
+		let service = Arc::new(MockService {
+			calls: AtomicUsize::new(0),
+			fail: true,
+		});
+		let headers = headers_with_skip("true");
+
+		let result = handle_delete_username(
+			service.as_ref(),
+			true,
+			&headers,
+			"0x0000000000000000000000000000000000000001",
+		)
+		.await;
+
+		let response = result.expect_err("should be server error").into_response();
+		assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+		assert_eq!(service.calls.load(Ordering::SeqCst), 1);
+	}
+}

--- a/src/routes/api/v1/internal/delete_username.rs
+++ b/src/routes/api/v1/internal/delete_username.rs
@@ -5,6 +5,7 @@ use axum::{
 	Extension,
 };
 use redis::aio::ConnectionManager;
+use subtle::ConstantTimeEq;
 use tracing::{info, instrument, warn};
 
 use crate::{
@@ -14,12 +15,14 @@ use crate::{
 };
 
 pub(super) const SKIP_ATTESTATION_HEADER: &str = "x-e2e-skip-attestation";
+pub(super) const INTERNAL_API_SECRET_HEADER: &str = "x-internal-api-secret";
 
 /// Returns `true` when the request is allowed to use the dev/internal endpoint:
 /// the runtime environment must allow skipping attestation (Development or Staging),
 /// and the request must carry `x-e2e-skip-attestation: true`.
 pub(super) fn is_e2e_skip_allowed(
 	allowed_to_skip_attestation: bool,
+	expected_secret: Option<&str>,
 	headers: &HeaderMap,
 ) -> bool {
 	let header_present = headers
@@ -27,7 +30,18 @@ pub(super) fn is_e2e_skip_allowed(
 		.and_then(|v| v.to_str().ok())
 		.is_some_and(|v| v == "true");
 
-	allowed_to_skip_attestation && header_present
+	let provided_secret = headers
+		.get(INTERNAL_API_SECRET_HEADER)
+		.and_then(|v| v.to_str().ok());
+
+	let secret_ok = match (expected_secret, provided_secret) {
+		(Some(expected), Some(provided)) if !expected.is_empty() => {
+			expected.as_bytes().ct_eq(provided.as_bytes()).into()
+		},
+		_ => false,
+	};
+
+	allowed_to_skip_attestation && header_present && secret_ok
 }
 
 /// Pure handler logic, decoupled from axum extensions for testability.
@@ -38,10 +52,11 @@ pub(super) fn is_e2e_skip_allowed(
 async fn handle_delete_username(
 	service: &dyn UsernameDeletionService,
 	allowed_to_skip_attestation: bool,
+	expected_secret: Option<&str>,
 	headers: &HeaderMap,
 	address: &str,
 ) -> Result<StatusCode, ErrorResponse> {
-	if !is_e2e_skip_allowed(allowed_to_skip_attestation, headers) {
+	if !is_e2e_skip_allowed(allowed_to_skip_attestation, expected_secret, headers) {
 		warn!("Dev delete_username endpoint called without valid e2e skip context");
 		return Err(ErrorResponse::forbidden(
 			"This endpoint is only available in dev/e2e contexts.".to_string(),
@@ -83,6 +98,7 @@ pub async fn delete_username(
 	handle_delete_username(
 		&service,
 		config.allowed_to_skip_attestation(),
+		config.internal_api_secret(),
 		&headers,
 		&address,
 	)
@@ -92,9 +108,9 @@ pub async fn delete_username(
 pub fn docs(op: TransformOperation) -> TransformOperation {
 	op.description(
 		"Dev/internal endpoint to delete a username record by wallet address. \
-		 Available only in Development/Staging environments and only when the \
-		 `x-e2e-skip-attestation: true` header is present. Intended for e2e \
-		 test cleanup; idempotent.",
+		 Available only in Development/Staging environments and only when both \
+		 `x-e2e-skip-attestation: true` and a matching `x-internal-api-secret` \
+		 header are present. Intended for e2e test cleanup; idempotent.",
 	)
 }
 
@@ -110,38 +126,83 @@ mod tests {
 		Arc,
 	};
 
+	const TEST_SECRET: &str = "test-internal-secret-do-not-use-in-prod";
+
+	fn headers_with(skip: Option<&'static str>, secret: Option<&'static str>) -> HeaderMap {
+		let mut headers = HeaderMap::new();
+		if let Some(v) = skip {
+			headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static(v));
+		}
+		if let Some(v) = secret {
+			headers.insert(INTERNAL_API_SECRET_HEADER, HeaderValue::from_static(v));
+		}
+		headers
+	}
+
 	#[test]
 	fn rejects_when_env_not_allowed() {
-		let mut headers = HeaderMap::new();
-		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static("true"));
-		assert!(!is_e2e_skip_allowed(false, &headers));
+		let headers = headers_with(Some("true"), Some(TEST_SECRET));
+		assert!(!is_e2e_skip_allowed(false, Some(TEST_SECRET), &headers));
 	}
 
 	#[test]
-	fn rejects_when_header_missing() {
-		let headers = HeaderMap::new();
-		assert!(!is_e2e_skip_allowed(true, &headers));
+	fn rejects_when_skip_header_missing() {
+		let headers = headers_with(None, Some(TEST_SECRET));
+		assert!(!is_e2e_skip_allowed(true, Some(TEST_SECRET), &headers));
 	}
 
 	#[test]
-	fn rejects_when_header_is_not_true() {
-		let mut headers = HeaderMap::new();
-		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static("false"));
-		assert!(!is_e2e_skip_allowed(true, &headers));
+	fn rejects_when_skip_header_is_not_true() {
+		let headers = headers_with(Some("false"), Some(TEST_SECRET));
+		assert!(!is_e2e_skip_allowed(true, Some(TEST_SECRET), &headers));
 	}
 
 	#[test]
-	fn rejects_when_header_is_empty() {
-		let mut headers = HeaderMap::new();
-		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static(""));
-		assert!(!is_e2e_skip_allowed(true, &headers));
+	fn rejects_when_skip_header_is_empty() {
+		let headers = headers_with(Some(""), Some(TEST_SECRET));
+		assert!(!is_e2e_skip_allowed(true, Some(TEST_SECRET), &headers));
 	}
 
 	#[test]
-	fn allows_when_env_and_header_set() {
-		let mut headers = HeaderMap::new();
-		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static("true"));
-		assert!(is_e2e_skip_allowed(true, &headers));
+	fn rejects_when_secret_header_missing() {
+		let headers = headers_with(Some("true"), None);
+		assert!(!is_e2e_skip_allowed(true, Some(TEST_SECRET), &headers));
+	}
+
+	#[test]
+	fn rejects_when_secret_header_does_not_match() {
+		let headers = headers_with(Some("true"), Some("nope"));
+		assert!(!is_e2e_skip_allowed(true, Some(TEST_SECRET), &headers));
+	}
+
+	#[test]
+	fn rejects_when_secret_header_is_empty() {
+		let headers = headers_with(Some("true"), Some(""));
+		assert!(!is_e2e_skip_allowed(true, Some(TEST_SECRET), &headers));
+	}
+
+	#[test]
+	fn rejects_when_expected_secret_is_none_even_if_header_present() {
+		let headers = headers_with(Some("true"), Some(TEST_SECRET));
+		assert!(
+			!is_e2e_skip_allowed(true, None, &headers),
+			"unset INTERNAL_API_SECRET must fail closed"
+		);
+	}
+
+	#[test]
+	fn rejects_when_expected_secret_is_empty_string() {
+		let headers = headers_with(Some("true"), Some(""));
+		assert!(
+			!is_e2e_skip_allowed(true, Some(""), &headers),
+			"empty expected secret must never authorize, even against an empty header"
+		);
+	}
+
+	#[test]
+	fn allows_when_env_and_both_headers_set_and_secret_matches() {
+		let headers = headers_with(Some("true"), Some(TEST_SECRET));
+		assert!(is_e2e_skip_allowed(true, Some(TEST_SECRET), &headers));
 	}
 
 	#[derive(Default)]
@@ -162,20 +223,15 @@ mod tests {
 		}
 	}
 
-	fn headers_with_skip(value: &'static str) -> HeaderMap {
-		let mut headers = HeaderMap::new();
-		headers.insert(SKIP_ATTESTATION_HEADER, HeaderValue::from_static(value));
-		headers
-	}
-
 	#[tokio::test]
-	async fn handler_returns_forbidden_in_production_even_with_header() {
+	async fn handler_returns_forbidden_in_production_even_with_headers() {
 		let service = Arc::new(MockService::default());
-		let headers = headers_with_skip("true");
+		let headers = headers_with(Some("true"), Some(TEST_SECRET));
 
 		let result = handle_delete_username(
 			service.as_ref(),
 			false,
+			Some(TEST_SECRET),
 			&headers,
 			"0x0000000000000000000000000000000000000001",
 		)
@@ -191,13 +247,56 @@ mod tests {
 	}
 
 	#[tokio::test]
-	async fn handler_returns_forbidden_in_dev_without_header() {
+	async fn handler_returns_forbidden_in_dev_without_headers() {
 		let service = Arc::new(MockService::default());
 		let headers = HeaderMap::new();
 
 		let result = handle_delete_username(
 			service.as_ref(),
 			true,
+			Some(TEST_SECRET),
+			&headers,
+			"0x0000000000000000000000000000000000000001",
+		)
+		.await;
+
+		let response = result.expect_err("should be forbidden").into_response();
+		assert_eq!(response.status(), StatusCode::FORBIDDEN);
+		assert_eq!(service.calls.load(Ordering::SeqCst), 0);
+	}
+
+	#[tokio::test]
+	async fn handler_returns_forbidden_when_secret_missing_in_config() {
+		let service = Arc::new(MockService::default());
+		let headers = headers_with(Some("true"), Some(TEST_SECRET));
+
+		let result = handle_delete_username(
+			service.as_ref(),
+			true,
+			None,
+			&headers,
+			"0x0000000000000000000000000000000000000001",
+		)
+		.await;
+
+		let response = result.expect_err("should be forbidden").into_response();
+		assert_eq!(response.status(), StatusCode::FORBIDDEN);
+		assert_eq!(
+			service.calls.load(Ordering::SeqCst),
+			0,
+			"deletion must not occur when INTERNAL_API_SECRET is unset"
+		);
+	}
+
+	#[tokio::test]
+	async fn handler_returns_forbidden_when_secret_does_not_match() {
+		let service = Arc::new(MockService::default());
+		let headers = headers_with(Some("true"), Some("wrong-secret"));
+
+		let result = handle_delete_username(
+			service.as_ref(),
+			true,
+			Some(TEST_SECRET),
 			&headers,
 			"0x0000000000000000000000000000000000000001",
 		)
@@ -211,11 +310,12 @@ mod tests {
 	#[tokio::test]
 	async fn handler_calls_service_and_returns_no_content_on_success() {
 		let service = Arc::new(MockService::default());
-		let headers = headers_with_skip("true");
+		let headers = headers_with(Some("true"), Some(TEST_SECRET));
 
 		let result = handle_delete_username(
 			service.as_ref(),
 			true,
+			Some(TEST_SECRET),
 			&headers,
 			"0xabCDEF0000000000000000000000000000000123",
 		)
@@ -231,11 +331,12 @@ mod tests {
 			calls: AtomicUsize::new(0),
 			fail: true,
 		});
-		let headers = headers_with_skip("true");
+		let headers = headers_with(Some("true"), Some(TEST_SECRET));
 
 		let result = handle_delete_username(
 			service.as_ref(),
 			true,
+			Some(TEST_SECRET),
 			&headers,
 			"0x0000000000000000000000000000000000000001",
 		)

--- a/src/routes/api/v1/internal/mod.rs
+++ b/src/routes/api/v1/internal/mod.rs
@@ -1,0 +1,12 @@
+use aide::axum::{routing::delete_with, ApiRouter};
+
+mod delete_username;
+
+use delete_username::{delete_username, docs as delete_username_docs};
+
+pub fn handler() -> ApiRouter {
+	ApiRouter::new().api_route(
+		"/usernames/:address",
+		delete_with(delete_username, delete_username_docs),
+	)
+}

--- a/src/routes/api/v1/mod.rs
+++ b/src/routes/api/v1/mod.rs
@@ -8,6 +8,7 @@ use std::sync::Arc;
 mod avatar;
 mod delete_profile_picture;
 mod ens_gateway;
+mod internal;
 mod profile_picture;
 mod query_multiple;
 mod query_single;
@@ -85,4 +86,5 @@ pub fn handler() -> ApiRouter {
 				},
 			)),
 		)
+		.nest("/internal", internal::handler())
 }


### PR DESCRIPTION
Adds DELETE /api/v1/internal/usernames/:address as a thin HTTP wrapper around the existing UsernameDeletionService so app-backend e2e tests can clean up rows created via POST /v1/usernames/register without leaking qa<...> usernames into staging.

The endpoint reuses the same dev/e2e gate as the attestation middleware: it requires APP_ENV in {development, staging} AND the x-e2e-skip-attestation: true header. Any other case returns 403. The underlying delete is idempotent.

CORPLAT-821

## PR Type

- [ ] Regular Task
- [ ] Bug Fix
- [ ] QA Tests

## Description

<!---
Describe what has been changed or added in this PR.

Please add enough context for:
1) A reviewer to understand the change
2) Other engineers trying to figure out why this code exists in the future
-->

## Checklist

<!-- Check all that apply and leave empty those that don't. -->

- [ ] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [ ] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.
