### PR TITLE
fix: prevent ENS gateway panic on malformed DNS-encoded names

### DIFF
--- a/src/routes/api/v1/ens_gateway.rs
+++ b/src/routes/api/v1/ens_gateway.rs
@@ -116,11 +116,11 @@ pub fn docs(op: aide::transform::TransformOperation) -> aide::transform::Transfo
 }
 
 fn decode_payload(payload: &ENSQueryPayload) -> Result<(Vec<u8>, String, Method), anyhow::Error> {
-	let data = if payload.data.ends_with(".json") {
-		&payload.data[2..payload.data.len() - 5]
-	} else {
-		&payload.data[2..]
-	};
+	let stripped = payload
+		.data
+		.strip_prefix("0x")
+		.ok_or_else(|| anyhow::anyhow!("payload data must start with 0x"))?;
+	let data = stripped.strip_suffix(".json").unwrap_or(stripped);
 	let req_data = hex::decode(data)?;
 	let decoded_req = ResolveRequest::abi_decode(&req_data, true)?;
 

--- a/src/types/ens.rs
+++ b/src/types/ens.rs
@@ -2,7 +2,6 @@
 
 use alloy::sol_types::{sol, SolCall};
 use anyhow::bail;
-use std::string::FromUtf8Error;
 
 use crate::utils::decode_ens_name;
 
@@ -39,8 +38,8 @@ pub enum Method {
 }
 
 impl resolveCall {
-	pub fn parse_name(&self) -> Result<String, FromUtf8Error> {
-		Ok(decode_ens_name(&String::from_utf8(self.name.to_vec())?))
+	pub fn parse_name(&self) -> anyhow::Result<String> {
+		decode_ens_name(&String::from_utf8(self.name.to_vec())?)
 	}
 
 	pub fn parse_method(&self) -> anyhow::Result<Method> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,19 +14,67 @@ pub fn namehash(name: &str) -> [u8; 32] {
 	})
 }
 
-pub fn decode_ens_name(name: &str) -> String {
+pub fn decode_ens_name(name: &str) -> anyhow::Result<String> {
+	use anyhow::Context;
+
+	let bytes = name.as_bytes();
 	let mut labels: Vec<&str> = Vec::new();
 	let mut idx = 0;
 	loop {
-		let len = name.as_bytes()[idx] as usize;
+		let len = *bytes
+			.get(idx)
+			.context("truncated DNS-encoded ENS name")? as usize;
 		if len == 0 {
 			break;
 		}
-		labels.push(&name[(idx + 1)..=(idx + len)]);
-		idx += len + 1;
+		let start = idx + 1;
+		let end = start + len;
+		let label = name
+			.get(start..end)
+			.context("invalid DNS-encoded ENS name label")?;
+		labels.push(label);
+		idx = end;
 	}
 
-	labels.join(".")
+	Ok(labels.join("."))
 }
 
 pub const ONE_MINUTE_IN_SECONDS: u64 = 60;
+
+#[cfg(test)]
+mod tests {
+	use super::*;
+
+	#[test]
+	fn decode_ens_name_round_trip() {
+		assert_eq!(
+			decode_ens_name("\x04test\x03eth\x00").unwrap(),
+			"test.eth"
+		);
+	}
+
+	#[test]
+	fn decode_ens_name_just_terminator() {
+		assert_eq!(decode_ens_name("\x00").unwrap(), "");
+	}
+
+	#[test]
+	fn decode_ens_name_empty_input() {
+		assert!(decode_ens_name("").is_err());
+	}
+
+	#[test]
+	fn decode_ens_name_missing_terminator() {
+		assert!(decode_ens_name("\x04test").is_err());
+	}
+
+	#[test]
+	fn decode_ens_name_length_overruns_input() {
+		assert!(decode_ens_name("\x0aab").is_err());
+	}
+
+	#[test]
+	fn decode_ens_name_label_splits_utf8_char() {
+		assert!(decode_ens_name("\x01\u{00c8}\x00").is_err());
+	}
+}


### PR DESCRIPTION
## PR Type

- [ ] Regular Task
- [x] Bug Fix
- [ ] QA Tests

## Description

`decode_ens_name` (`src/utils.rs`) and `decode_payload` (`src/routes/api/v1/ens_gateway.rs`) performed unchecked byte indexing and string slicing on attacker-controlled `/api/v1/ens` input — a malformed DNS-wire-encoded name (missing zero terminator, length byte overrunning input, or label range landing mid-UTF-8-char) or a `data` field shorter than 2 chars would panic, and with the release profile's `panic = "abort"` (no `CatchPanic` is viable under abort) a single unauthenticated request crashed the process.

Replaced the indexing with `bytes.get` / `str::get` / `strip_prefix` / `strip_suffix` so all malformed inputs surface as the existing 400 "Failed to decode payload." response, and added unit tests covering each panic vector plus the happy path.

## Checklist

- [x] I have self-reviewed this PR.
- [ ] I have left comments in the code for clarity.
- [x] I have added necessary unit tests.
- [ ] I have updated the documentation as needed.