### PR TITLE
fix(search): bound the OpenSearch query + stop the startup panic (DEV-2800)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,6 +44,8 @@ REDIS_PORT=6379
 # OpenSearch
 OPENSEARCH_ENDPOINT=http://localhost:9200
 OPENSEARCH_INDEX_NAME=names
+# Hard deadline for the /search OpenSearch query before returning 503.
+SEARCH_OPENSEARCH_TIMEOUT_MS=2000
 
 # DataDog Agent
 DD_API_KEY=NOT_SET

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,6 +79,11 @@ pub struct Config {
 	pub attestation_jwks_url: String,
 	pub whitelisted_avatar_domains: Option<Vec<String>>,
 	pub environment: Environment,
+	/// Hard upper bound on how long `/search` waits for `OpenSearch` before
+	/// returning a retryable 503. Keeps a slow query (staging p99 ~15s, max
+	/// ~29s) from hanging the request and tripping upstream/client deadlines.
+	/// Tunable via `SEARCH_OPENSEARCH_TIMEOUT_MS`.
+	pub search_opensearch_timeout: Duration,
 	/// Shared secret for `/api/v1/internal/*` endpoints. Loaded from the
 	/// `INTERNAL_API_SECRET` env var. `None` when unset or empty, in which case
 	/// every internal endpoint must respond with 403 regardless of `APP_ENV`.
@@ -180,8 +185,14 @@ impl Config {
 			.ok()
 			.filter(|s| !s.is_empty());
 
+		// Conservative default: prod OpenSearch p99 is ~1s, so 2s lets ~all
+		// queries finish on the fast path while capping the catastrophic tail.
+		let search_opensearch_timeout =
+			Duration::from_millis(env_millis("SEARCH_OPENSEARCH_TIMEOUT_MS", 2000));
+
 		Ok(Self {
 			environment,
+			search_opensearch_timeout,
 			db_client: Some(db_client),
 			db_read_client: Some(db_read_client),
 			blocklist: Some(blocklist),
@@ -267,6 +278,7 @@ impl Config {
 
 		Self {
 			environment: env,
+			search_opensearch_timeout: Duration::from_millis(2000),
 			wld_app_id: unsafe { AppId::new_unchecked("app_test_app_id".to_string()) },
 			ens_domain: "test.eth".to_string(),
 			private_key: "test_private_key".to_string(),
@@ -286,6 +298,15 @@ impl Config {
 			blocklist: None,
 		}
 	}
+}
+
+/// Parse a millisecond-valued env var, falling back to `default` when unset or
+/// unparseable (a bad value should not take down search configuration).
+fn env_millis(var: &str, default: u64) -> u64 {
+	env::var(var)
+		.ok()
+		.and_then(|v| v.trim().parse::<u64>().ok())
+		.unwrap_or(default)
 }
 
 async fn build_redis_pool(mut redis_url: String) -> redis::RedisResult<ConnectionManager> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use aws_config::BehaviorVersion;
 use aws_sdk_s3::Client as S3Client;
 use axum::Extension;
 use idkit::session::AppId;
-use once_cell::sync::OnceCell;
+use tokio::sync::OnceCell;
 use redis::aio::ConnectionManager;
 use regex::Regex;
 use sqlx::{migrate::MigrateError, postgres::PgPoolOptions, PgPool};
@@ -37,7 +37,7 @@ pub static DEVICE_USERNAME_REGEX: LazyLock<Regex> =
 pub static USERNAME_SEARCH_REGEX: LazyLock<Regex> =
 	LazyLock::new(|| Regex::new(r"(?-u)^[a-z]\w{0,13}([a-z0-9](\.\d{1,4})?)$").unwrap());
 
-pub static OPENSEARCH_CLIENT: OnceCell<Arc<OpenSearchClient>> = OnceCell::new();
+pub static OPENSEARCH_CLIENT: OnceCell<Arc<OpenSearchClient>> = OnceCell::const_new();
 
 #[derive(Clone)]
 pub struct ConnectionManagerDebug {
@@ -181,7 +181,10 @@ impl Config {
 					let _ = OPENSEARCH_CLIENT.set(Arc::new(client));
 				},
 				Err(e) => {
-					tracing::error!("❌ Failed to connect to OpenSearch: {}", e);
+					tracing::error!(
+						"❌ Failed to connect to OpenSearch at startup (will retry lazily on first search): {}",
+						e
+					);
 				},
 			}
 		}
@@ -324,8 +327,18 @@ async fn build_redis_pool(mut redis_url: String) -> redis::RedisResult<Connectio
 	ConnectionManager::new(client).await
 }
 
-pub fn get_opensearch_client() -> Option<Arc<OpenSearchClient>> {
-	OPENSEARCH_CLIENT.get().cloned()
+/// Return the `OpenSearch` client, lazily (re)building it if it was not
+/// initialised at startup — e.g. `OpenSearch` was briefly unavailable when the
+/// process booted. On a build failure the cell is left empty so the next call
+/// retries, letting search self-heal instead of returning 503 for the entire
+/// lifetime of the process (concurrent callers are serialised by the cell, so
+/// at most one build runs at a time).
+pub async fn get_or_init_opensearch_client() -> Option<Arc<OpenSearchClient>> {
+	OPENSEARCH_CLIENT
+		.get_or_try_init(|| async { OpenSearchClient::new().await.map(Arc::new) })
+		.await
+		.ok()
+		.cloned()
 }
 
 #[cfg(test)]

--- a/src/routes/api/v1/search.rs
+++ b/src/routes/api/v1/search.rs
@@ -1,5 +1,7 @@
+use std::time::Duration;
+
 use crate::{
-	config::{get_opensearch_client, USERNAME_SEARCH_REGEX},
+	config::{get_opensearch_client, ConfigExt, USERNAME_SEARCH_REGEX},
 	types::{ErrorResponse, UsernameRecord},
 	utils::ONE_MINUTE_IN_SECONDS,
 };
@@ -10,9 +12,11 @@ use axum::{
 };
 use axum_jsonschema::Json;
 use redis::{aio::ConnectionManager, AsyncCommands};
+use tokio::time::timeout;
 use tracing::{info_span, Instrument};
 
 pub async fn search(
+	Extension(config): ConfigExt,
 	Extension(mut redis): Extension<ConnectionManager>,
 	Path(username): Path<String>,
 ) -> Result<Response, ErrorResponse> {
@@ -31,33 +35,59 @@ pub async fn search(
 		}
 	}
 
-	let opensearch_client = get_opensearch_client().expect("OpenSearch client should be available");
+	// OpenSearch is a hard dependency for this endpoint, but a bounded one:
+	// - never hang on a slow query (staging saw p99 ~15s, max ~29s), and
+	// - never panic if the client failed to initialise at startup (the old
+	//   `.expect()` aborted the whole process under panic=abort).
+	// On any failure we return a retryable 503 rather than a 500 or a hang.
+	let Some(client) = get_opensearch_client() else {
+		tracing::error!("OpenSearch client unavailable");
+		return Err(ErrorResponse::service_unavailable(
+			"Search is temporarily unavailable".to_string(),
+		));
+	};
 
-	match opensearch_client
-		.search_usernames(&lowercase_username, 10)
-		.instrument(info_span!(
-			"search_opensearch_query",
-			username = lowercase_username
-		))
-		.await
+	let deadline = config.search_opensearch_timeout;
+	// Ask OpenSearch to self-limit slightly before our hard client deadline so
+	// we usually get a clean response back rather than dropping the connection.
+	let server_timeout = deadline
+		.saturating_sub(Duration::from_millis(250))
+		.max(Duration::from_millis(100));
+
+	let records = match timeout(
+		deadline,
+		client
+			.search_usernames(&lowercase_username, 10, server_timeout)
+			.instrument(info_span!(
+				"search_opensearch_query",
+				username = lowercase_username
+			)),
+	)
+	.await
 	{
-		Ok(records) => {
-			// cache the results
-			if let Ok(json_data) = serde_json::to_string(&records) {
-				let _: Result<(), redis::RedisError> = redis
-					.set_ex(&cache_key, json_data, ONE_MINUTE_IN_SECONDS * 5)
-					.await;
-			}
+		Ok(Ok(records)) => records,
+		Ok(Err(e)) => {
+			tracing::error!(error = %e, "OpenSearch search failed");
+			return Err(ErrorResponse::service_unavailable(
+				"Search is temporarily unavailable".to_string(),
+			));
+		},
+		Err(_elapsed) => {
+			tracing::error!(timeout = ?deadline, "OpenSearch search timed out");
+			return Err(ErrorResponse::service_unavailable(
+				"Search is temporarily unavailable".to_string(),
+			));
+		},
+	};
 
-			Ok(Json(records).into_response())
-		},
-		Err(e) => {
-			tracing::error!("OpenSearch search failed: {}", e);
-			Err(ErrorResponse::server_error(
-				"Search service failure".to_string(),
-			))
-		},
+	// cache the results
+	if let Ok(json_data) = serde_json::to_string(&records) {
+		let _: Result<(), redis::RedisError> = redis
+			.set_ex(&cache_key, json_data, ONE_MINUTE_IN_SECONDS * 5)
+			.await;
 	}
+
+	Ok(Json(records).into_response())
 }
 
 pub fn docs(op: aide::transform::TransformOperation) -> aide::transform::TransformOperation {

--- a/src/routes/api/v1/search.rs
+++ b/src/routes/api/v1/search.rs
@@ -1,7 +1,9 @@
 use std::time::Duration;
 
+use anyhow::Context;
+
 use crate::{
-	config::{get_opensearch_client, ConfigExt, USERNAME_SEARCH_REGEX},
+	config::{get_or_init_opensearch_client, ConfigExt, USERNAME_SEARCH_REGEX},
 	types::{ErrorResponse, UsernameRecord},
 	utils::ONE_MINUTE_IN_SECONDS,
 };
@@ -35,18 +37,12 @@ pub async fn search(
 		}
 	}
 
-	// OpenSearch is a hard dependency for this endpoint, but a bounded one:
-	// - never hang on a slow query (staging saw p99 ~15s, max ~29s), and
-	// - never panic if the client failed to initialise at startup (the old
-	//   `.expect()` aborted the whole process under panic=abort).
-	// On any failure we return a retryable 503 rather than a 500 or a hang.
-	let Some(client) = get_opensearch_client() else {
-		tracing::error!("OpenSearch client unavailable");
-		return Err(ErrorResponse::service_unavailable(
-			"Search is temporarily unavailable".to_string(),
-		));
-	};
-
+	// OpenSearch is a hard dependency for this endpoint, but a bounded one. The
+	// whole operation — lazily (re)initialising the client if a transient
+	// startup failure left it unset, then querying — runs under a single hard
+	// deadline, so a slow or unavailable OpenSearch never hangs the request. On
+	// any failure we return a retryable 503, rather than a 500, a hang, or (as
+	// before) a process-aborting panic when the client is missing.
 	let deadline = config.search_opensearch_timeout;
 	// Ask OpenSearch to self-limit slightly before our hard client deadline so
 	// we usually get a clean response back rather than dropping the connection.
@@ -54,17 +50,20 @@ pub async fn search(
 		.saturating_sub(Duration::from_millis(250))
 		.max(Duration::from_millis(100));
 
-	let records = match timeout(
-		deadline,
+	let query = async {
+		let client = get_or_init_opensearch_client()
+			.await
+			.context("OpenSearch client unavailable")?;
 		client
 			.search_usernames(&lowercase_username, 10, server_timeout)
 			.instrument(info_span!(
 				"search_opensearch_query",
 				username = lowercase_username
-			)),
-	)
-	.await
-	{
+			))
+			.await
+	};
+
+	let records = match timeout(deadline, query).await {
 		Ok(Ok(records)) => records,
 		Ok(Err(e)) => {
 			tracing::error!(error = %e, "OpenSearch search failed");

--- a/src/search/opensearch.rs
+++ b/src/search/opensearch.rs
@@ -62,6 +62,24 @@ impl OpenSearchClient {
 		Ok(opensearch_client)
 	}
 
+	/// Build a client pointing at an arbitrary endpoint without the startup
+	/// index-existence check. Test-only seam so we can drive `search_usernames`
+	/// against a mock server.
+	#[cfg(test)]
+	fn with_endpoint(url: &str, index_name: &str) -> Result<Self> {
+		let base_url = Url::parse(url).context("Failed to parse OpenSearch URL")?;
+		let conn_pool = SingleNodeConnectionPool::new(base_url);
+		let transport = TransportBuilder::new(conn_pool)
+			.timeout(Duration::from_secs(5))
+			.cert_validation(CertificateValidation::None)
+			.disable_proxy()
+			.build()?;
+		Ok(Self {
+			client: OpenSearch::new(transport),
+			index_name: index_name.to_string(),
+		})
+	}
+
 	async fn ensure_index_exists(&self) -> Result<()> {
 		// check if index exists
 		let response = self
@@ -153,10 +171,22 @@ impl OpenSearchClient {
 		Ok(())
 	}
 
-	/// search for usernames with fuzzy matching
-	pub async fn search_usernames(&self, query: &str, limit: usize) -> Result<Vec<UsernameRecord>> {
+	/// search for usernames with fuzzy matching.
+	///
+	/// `server_timeout` is passed through as the `OpenSearch` request-body
+	/// `timeout` so the cluster stops working on a slow query instead of
+	/// churning after the caller has given up. It is best-effort: a
+	/// `timed_out: true` response is treated as a failure. The authoritative
+	/// deadline is the caller's `tokio::time::timeout`.
+	pub async fn search_usernames(
+		&self,
+		query: &str,
+		limit: usize,
+		server_timeout: Duration,
+	) -> Result<Vec<UsernameRecord>> {
 		let search_query = json!({
 			"size": limit,
+			"timeout": format!("{}ms", server_timeout.as_millis()),
 			"query": {
 				"bool": {
 					"should": [
@@ -199,6 +229,16 @@ impl OpenSearchClient {
 		}
 
 		let response_body = response.json::<Value>().await?;
+
+		// OpenSearch hit its server-side `timeout` and returned partial results;
+		// surface it as an error so the caller returns 503 rather than serving an
+		// incomplete result set.
+		if response_body["timed_out"].as_bool() == Some(true) {
+			return Err(anyhow::anyhow!(
+				"OpenSearch reported timed_out=true (server_timeout exceeded)"
+			));
+		}
+
 		let hits = response_body["hits"]["hits"]
 			.as_array()
 			.context("Expected hits array in response")?;
@@ -244,5 +284,80 @@ impl OpenSearchClient {
 		}
 
 		Ok(results)
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::OpenSearchClient;
+	use std::time::Duration;
+	use wiremock::matchers::{method, path};
+	use wiremock::{Mock, MockServer, ResponseTemplate};
+
+	fn client_for(server: &MockServer) -> OpenSearchClient {
+		OpenSearchClient::with_endpoint(&server.uri(), "names").unwrap()
+	}
+
+	async fn mount_search(server: &MockServer, template: ResponseTemplate) {
+		Mock::given(method("POST"))
+			.and(path("/names/_search"))
+			.respond_with(template)
+			.mount(server)
+			.await;
+	}
+
+	#[tokio::test]
+	async fn parses_hits_on_success() {
+		let server = MockServer::start().await;
+		let body = serde_json::json!({
+			"timed_out": false,
+			"hits": { "hits": [{ "_source": {
+				"username": "alice",
+				"address": "0x0000000000000000000000000000000000000001"
+			}}]}
+		});
+		mount_search(&server, ResponseTemplate::new(200).set_body_json(body)).await;
+
+		let records = client_for(&server)
+			.search_usernames("ali", 10, Duration::from_secs(1))
+			.await
+			.expect("successful search should parse");
+
+		assert_eq!(records.len(), 1);
+		assert_eq!(records[0].username, "alice");
+	}
+
+	#[tokio::test]
+	async fn errors_on_upstream_5xx() {
+		// A 5xx from OpenSearch must surface as Err so the handler returns 503
+		// rather than a 500 or a hang.
+		let server = MockServer::start().await;
+		mount_search(
+			&server,
+			ResponseTemplate::new(503).set_body_string("service unavailable"),
+		)
+		.await;
+
+		let result = client_for(&server)
+			.search_usernames("ali", 10, Duration::from_secs(1))
+			.await;
+
+		assert!(result.is_err(), "5xx should surface as Err");
+	}
+
+	#[tokio::test]
+	async fn errors_on_server_side_timed_out() {
+		// OpenSearch hit its request-body `timeout` and returned partial results
+		// with `timed_out: true`; treat as a failure so we don't serve an
+		// incomplete result set.
+		let server = MockServer::start().await;
+		let body = serde_json::json!({ "timed_out": true, "hits": { "hits": [] } });
+		mount_search(&server, ResponseTemplate::new(200).set_body_json(body)).await;
+
+		let result = client_for(&server)
+			.search_usernames("ali", 10, Duration::from_secs(1))
+			.await;
+
+		assert!(result.is_err(), "timed_out=true should surface as Err");
 	}
 }

--- a/src/types/error.rs
+++ b/src/types/error.rs
@@ -58,6 +58,16 @@ impl ErrorResponse {
 		}
 	}
 
+	/// 503 Service Unavailable. Use for transient dependency breakage where the
+	/// caller should retry (e.g. search backends are all unavailable). Unlike a
+	/// 500, this signals the failure is expected-to-be-temporary and retryable.
+	pub const fn service_unavailable(error: String) -> Self {
+		Self {
+			error,
+			status: StatusCode::SERVICE_UNAVAILABLE,
+		}
+	}
+
 	pub const fn forbidden(error: String) -> Self {
 		Self {
 			error,


### PR DESCRIPTION
## Summary

`/v1/usernames/search` intermittently returned **HTTP 500** (DEV-2800): OpenSearch was an **unbounded hard dependency** — slow queries (staging p99 ~15s, max ~29s; prod ~1s) hung the request until an upstream/client deadline fired, and a missing OpenSearch client hit `.expect()` and **panicked the process** under `panic = "abort"`.

This PR is the **application robustness fix**. The staging slowness itself is fixed on the infra side — resizing staging OpenSearch off the burstable `t3.small` cluster — in worldcoin/world-id-deploy#533.

## What changed
- **Bound the query**: a hard, configurable client deadline (`SEARCH_OPENSEARCH_TIMEOUT_MS`, default 2000ms) + a server-side `timeout` body param and a `timed_out` check. No more 15–30s hangs.
- **Remove the `.expect()` panic**: a missing/uninitialised OpenSearch client no longer aborts the process.
- **Fail cleanly**: any failure/timeout/unavailable now returns a **retryable 503** instead of a 500 or a hang.
- Tests (wiremock): 5xx → error, server-side `timed_out` → error, success parsing.

## Scope note
This is deliberately the **lean fix**. An earlier draft also added a Postgres prefix fallback (+ a new index) and an edge-ngram query optimization; those were dropped as out-of-scope for the 500 — the fallback needed a permanent new index built `CONCURRENTLY` at startup (real rollout risk), and the resize alone should get staging fast. Edge-ngram remains a tracked follow-up if we later want prefix search at ~50ms instead of ~1s.

## Behavior
- Happy path unchanged (OpenSearch primary, cached 5 min).
- On the ticket's failure mode: fast, clean 503 instead of a hung 500 / process crash. (The e2e tests go green via the infra resize, which makes OpenSearch fast on staging.)

## Testing
Build + 36 tests green locally (`SQLX_OFFLINE`), clippy clean on changed files. CI runs only Foundry tests, so the Rust tests were run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
