### PR TITLE
fix: reject non-ASCII (homoglyph) usernames in validation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -25,12 +25,17 @@ use crate::{
 #[allow(clippy::module_name_repetitions)]
 pub type ConfigExt = Extension<Arc<Config>>;
 
+// `(?-u)` disables Unicode mode so `\w` and `\d` mean ASCII `[0-9A-Za-z_]` /
+// `[0-9]` only. Without it, Rust's regex crate treats `\w`/`\d` as Unicode-aware,
+// so Cyrillic/other homoglyphs (e.g. `vit\u{0430}lik`) and non-ASCII digits
+// satisfy the middle of a username and can be registered to impersonate a
+// look-alike name. Reported via HackerOne #3699374 and #3704866.
 pub static USERNAME_REGEX: LazyLock<Regex> =
-	LazyLock::new(|| Regex::new(r"^[a-z]\w{2,13}[a-z0-9]$").unwrap());
+	LazyLock::new(|| Regex::new(r"(?-u)^[a-z]\w{2,13}[a-z0-9]$").unwrap());
 pub static DEVICE_USERNAME_REGEX: LazyLock<Regex> =
-	LazyLock::new(|| Regex::new(r"^[a-z]\w{2,13}[a-z0-9]\.\d{4}$").unwrap());
+	LazyLock::new(|| Regex::new(r"(?-u)^[a-z]\w{2,13}[a-z0-9]\.\d{4}$").unwrap());
 pub static USERNAME_SEARCH_REGEX: LazyLock<Regex> =
-	LazyLock::new(|| Regex::new(r"^[a-z]\w{0,13}([a-z0-9](\.\d{1,4})?)$").unwrap());
+	LazyLock::new(|| Regex::new(r"(?-u)^[a-z]\w{0,13}([a-z0-9](\.\d{1,4})?)$").unwrap());
 
 pub static OPENSEARCH_CLIENT: OnceCell<Arc<OpenSearchClient>> = OnceCell::new();
 
@@ -300,4 +305,48 @@ async fn build_redis_pool(mut redis_url: String) -> redis::RedisResult<Connectio
 
 pub fn get_opensearch_client() -> Option<Arc<OpenSearchClient>> {
 	OPENSEARCH_CLIENT.get().cloned()
+}
+
+#[cfg(test)]
+mod regex_tests {
+	use super::{DEVICE_USERNAME_REGEX, USERNAME_REGEX, USERNAME_SEARCH_REGEX};
+
+	#[test]
+	fn accepts_valid_ascii_usernames() {
+		for u in ["abcd", "vitalik", "alice1", "bob_the_builder"] {
+			assert!(USERNAME_REGEX.is_match(u), "should accept {u}");
+		}
+	}
+
+	#[test]
+	fn rejects_non_ascii_homoglyphs() {
+		// Cyrillic 'а' (U+0430) is visually identical to ASCII 'a'.
+		assert!(
+			!USERNAME_REGEX.is_match("vit\u{0430}lik"),
+			"Unicode homoglyph must be rejected (HackerOne #3699374 / #3704866)"
+		);
+		// Other non-ASCII word characters anywhere in the name.
+		for u in [
+			"\u{0430}dmin1",   // leading Cyrillic 'а'
+			"v\u{0456}talik",  // Cyrillic 'і'
+			"vitalik\u{200b}", // trailing zero-width space
+		] {
+			assert!(!USERNAME_REGEX.is_match(u), "should reject {u:?}");
+		}
+	}
+
+	#[test]
+	fn device_regex_rejects_non_ascii() {
+		assert!(DEVICE_USERNAME_REGEX.is_match("vitalik.1234"));
+		// Arabic-Indic digits must not satisfy the \d{4} device suffix.
+		assert!(!DEVICE_USERNAME_REGEX.is_match("vitalik.\u{0661}\u{0662}\u{0663}\u{0664}"));
+		assert!(!DEVICE_USERNAME_REGEX.is_match("vit\u{0430}lik.1234"));
+	}
+
+	#[test]
+	fn search_regex_is_ascii_only() {
+		assert!(USERNAME_SEARCH_REGEX.is_match("vitalik"));
+		assert!(USERNAME_SEARCH_REGEX.is_match("vital.12"));
+		assert!(!USERNAME_SEARCH_REGEX.is_match("vit\u{0430}lik"));
+	}
 }


### PR DESCRIPTION
## Summary

Fixes **HackerOne #3699374** and **#3704866** (same root cause) — usernames could contain non-ASCII homoglyphs, enabling impersonation/spoofing.

`USERNAME_REGEX`, `DEVICE_USERNAME_REGEX`, and `USERNAME_SEARCH_REGEX` validate with `\w` (and `\d`). Rust's `regex` crate treats these as **Unicode-aware by default**, and only the first/last characters of a username are pinned to ASCII (`[a-z]` / `[a-z0-9]`). The middle `\w{2,13}` therefore accepts any Unicode word character.

Impact:
- An attacker with a single World ID can register a homoglyph of a popular or reserved name — e.g. `vitаlik` where the third `а` is Cyrillic U+0430 — pointing at their own address. It is visually identical to the real handle.
- The blocklist (`to_lowercase()` + substring match) doesn't normalize Unicode, so reserved-name protection is bypassed too.
- The spoofed row surfaces through the public, unauthenticated search / query / reverse-lookup endpoints and the ENS gateway, so it can be used to redirect payments to the wrong address.
- `DEVICE_USERNAME_REGEX`'s `\d{4}` suffix likewise accepted non-ASCII digits (e.g. Arabic-Indic).

## Fix

Prefix each pattern with `(?-u)`, which disables Unicode mode so `\w` means ASCII `[0-9A-Za-z_]` and `\d` means `[0-9]`.

- **No behavior change for ASCII inputs** — `(?-u)\w` still includes `A–Z`/`_` exactly as the Unicode `\w` did for ASCII, so existing valid usernames keep validating.
- Non-ASCII usernames are now rejected uniformly at **registration, rename, and search** (all three share these regexes).
- Minimal and dependency-free (no normalization/confusables library needed): closing registration at the regex is the upstream gate, which also moots the blocklist's lack of normalization for this vector.

Adds `config::regex_tests` covering: valid ASCII accepted; Cyrillic homoglyph + other non-ASCII word chars + zero-width space rejected; device suffix rejects non-ASCII digits; search regex ASCII-only.

## Verification

- `cargo test --bin wld-usernames regex` → 4/4 pass (also confirms the `(?-u)` patterns compile — the crate's `regex::Regex` requires patterns to only match valid UTF-8, which these do).
- `SQLX_OFFLINE=true cargo check` / `cargo clippy` clean (no new warnings); no SQL or `.sqlx` changes.

## Out of scope / follow-ups

- **Existing** homoglyph rows already in the DB are not removed here — they can be cleaned up with the internal delete endpoint.
- Defense-in-depth (NFKC normalization + UTS-39 confusable/skeleton checks in the blocklist) and making the case-insensitive uniqueness index `UNIQUE` (closes the concurrent-registration race) are worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
